### PR TITLE
Switch to LLVM-based code coverage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run code coverage
         run: |
-          cargo +nightly test
+          LLVM_PROFILE_FILE="%m.profraw" cargo +nightly test
 
           ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info;
           bash <(curl -s https://codecov.io/bash) -f lcov.info;

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,13 +74,10 @@ jobs:
         run: |
           cargo +nightly test
 
-          zip -0 ccov.zip `find . \( -name "pliantdb*.gc*" \) -print`;
-          rm -rf target
-
-          ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" --ignore "/target" -o lcov.info;
+          ./grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing -o lcov.info;
           bash <(curl -s https://codecov.io/bash) -f lcov.info;
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests" # TODO: https://github.com/alexcrichton/proc-macro2/issues/218
+          RUSTFLAGS: "-Zinstrument-coverage" # TODO: https://github.com/alexcrichton/proc-macro2/issues/218
           RUSTDOCFLAGS: "-Cpanic=abort"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,5 +79,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zinstrument-coverage" # TODO: https://github.com/alexcrichton/proc-macro2/issues/218
+          RUSTFLAGS: "-Zinstrument-coverage -Copt-level=0 -Clink-dead-code"
           RUSTDOCFLAGS: "-Cpanic=abort"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -79,5 +79,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zinstrument-coverage -Copt-level=0 -Clink-dead-code"
+          RUSTFLAGS: "-Zinstrument-coverage"
           RUSTDOCFLAGS: "-Cpanic=abort"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,10 @@ jobs:
         run: |
           rustup component add llvm-tools-preview
           rustup install nightly
-          curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+          # Current versions are causing "[ERROR] Execution count overflow detected."
+          # https://github.com/mozilla/grcov/issues/555
+          # curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+          curl -L https://github.com/mozilla/grcov/releases/download/v0.6.1/grcov-linux-x86_64.tar.bz2 | tar jxf -
 
       - name: Run code coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Cargo.lock
 .vscode
 *.pliantdb
+*.profraw
+*.profdata
+coverage/


### PR DESCRIPTION
The code coverage from `-Zprofile` isn't very good -- it tracks documentation lines as code and has issues within the ecosystem requiring a lot of extra compiler flags. I stumbled upon `-Zinstrument-coverage` which uses the LLVM coverage tools and should provide much more accurate results.

This PR works and enables it, but unfortunately, it only tracks a single test's coverage due to rust-lang/rust#79899. So, the main branch will use the original coverage until that is resolved -- sounds like it could be a decent task to get involved in those projects.

