### PR TITLE
Implement mapped views

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zinstrument-coverage -Cinline-threshold=0"
+          RUSTFLAGS: "-Zinstrument-coverage"
           RUSTDOCFLAGS: "-Cpanic=abort"
 
       - name: Deploy Docs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-Zinstrument-coverage -Cinline-threshold=0"
           RUSTDOCFLAGS: "-Cpanic=abort"
 
       - name: Deploy Docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 
-members = ["pliantdb", "core", "local"]
+members = ["pliantdb", "core", "local", "jobs"]

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -127,6 +127,20 @@ where
         self
     }
 
+    /// Filters for entries in the view with `keys`.
+    #[must_use]
+    pub fn with_keys(mut self, keys: Vec<V::MapKey>) -> Self {
+        self.key = Some(QueryKey::Multiple(keys));
+        self
+    }
+
+    /// Filters for entries in the view with `keys`.
+    #[must_use]
+    pub fn with_key_range(mut self, range: Range<V::MapKey>) -> Self {
+        self.key = Some(QueryKey::Range(range));
+        self
+    }
+
     /// Executes the query and retrieves the results.
     pub async fn query(self) -> Result<Vec<map::Serialized>, Error> {
         self.connection.query(self).await

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -34,7 +34,7 @@ pub trait Connection<'a>: Send + Sync {
 
     /// Initializes [`ViewQuery`] for [`schema::View`] `V`.
     #[must_use]
-    fn view<'k, V: schema::View<'k>>(&'a self) -> View<'a, 'k, Self, V>
+    fn view<V: schema::View>(&'a self) -> View<'a, Self, V>
     where
         Self: Sized,
     {
@@ -43,10 +43,10 @@ pub trait Connection<'a>: Send + Sync {
 
     /// Initializes [`ViewQuery`] for [`schema::View`] `V`.
     #[must_use]
-    async fn query<'k, V: schema::View<'k>>(
+    async fn query<'k, V: schema::View>(
         &self,
-        query: View<'a, 'k, Self, V>,
-    ) -> Result<Vec<map::Serialized<'static>>, Error>
+        query: View<'a, Self, V>,
+    ) -> Result<Vec<map::Serialized>, Error>
     where
         Self: Sized;
 
@@ -102,15 +102,15 @@ where
 }
 
 /// Parameters to query a `schema::View`.
-pub struct View<'a, 'k, Cn, V: schema::View<'k>> {
+pub struct View<'a, Cn, V: schema::View> {
     connection: &'a Cn,
     /// Key filtering criteria.
     pub key: Option<QueryKey<V::MapKey>>,
 }
 
-impl<'a, 'k, Cn, V> View<'a, 'k, Cn, V>
+impl<'a, Cn, V> View<'a, Cn, V>
 where
-    V: schema::View<'k>,
+    V: schema::View,
     Cn: Connection<'a>,
 {
     fn new(connection: &'a Cn) -> Self {
@@ -128,7 +128,7 @@ where
     }
 
     /// Executes the query and retrieves the results.
-    pub async fn query(self) -> Result<Vec<map::Serialized<'static>>, Error> {
+    pub async fn query(self) -> Result<Vec<map::Serialized>, Error> {
         self.connection.query(self).await
     }
 }

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -34,7 +34,7 @@ pub trait Connection<'a>: Send + Sync {
 
     /// Initializes [`ViewQuery`] for [`schema::View`] `V`.
     #[must_use]
-    async fn view<'k, V: schema::View<'k>>(&'a self) -> View<'a, 'k, Self, V>
+    fn view<'k, V: schema::View<'k>>(&'a self) -> View<'a, 'k, Self, V>
     where
         Self: Sized,
     {
@@ -105,7 +105,7 @@ where
 pub struct View<'a, 'k, Cn, V: schema::View<'k>> {
     connection: &'a Cn,
     /// Key filtering criteria.
-    pub key: Option<QueryKey<'k, V::MapKey>>,
+    pub key: Option<QueryKey<V::MapKey>>,
 }
 
 impl<'a, 'k, Cn, V> View<'a, 'k, Cn, V>
@@ -122,7 +122,7 @@ where
 
     /// Filters for entries in the view with `key`.
     #[must_use]
-    pub fn with_key(mut self, key: &'k V::MapKey) -> Self {
+    pub fn with_key(mut self, key: V::MapKey) -> Self {
         self.key = Some(QueryKey::Matches(key));
         self
     }
@@ -134,13 +134,13 @@ where
 }
 
 /// Filters a [`View`] by key.
-pub enum QueryKey<'k, K> {
+pub enum QueryKey<K> {
     /// Matches all entries with the key provided.
-    Matches(&'k K),
+    Matches(K),
 
     /// Matches all entires with keys in the range provided.
-    Range(Range<&'k K>),
+    Range(Range<K>),
 
     /// Matches all entries that have keys that are included in the set provided.
-    Multiple(&'k [K]),
+    Multiple(Vec<K>),
 }

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -131,14 +131,7 @@ fn emissions_tests() -> Result<(), crate::Error> {
         test_util::Basic,
     };
 
-    let doc = Document::with_contents(
-        1,
-        &Basic {
-            value: String::default(),
-            parent_id: None,
-        },
-        Basic::id(),
-    )?;
+    let doc = Document::with_contents(1, &Basic::default(), Basic::id())?;
 
     assert_eq!(doc.emit(), Map::new(doc.header.id, (), ()));
 

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -93,7 +93,7 @@ impl<'a> Document<'a> {
 
     /// Creates a `Map` result with a `key` and an empty value.
     #[must_use]
-    pub fn emit_key<'k, Key: map::Key<'k>>(&self, key: Key) -> Map<'k, Key, ()> {
+    pub fn emit_key<'k, Key: map::Key>(&self, key: Key) -> Map<'k, Key, ()> {
         self.emit_key_and_value(key, ())
     }
 
@@ -105,7 +105,7 @@ impl<'a> Document<'a> {
 
     /// Creates a `Map` result with a `key` and `value`.
     #[must_use]
-    pub fn emit_key_and_value<'k, Key: map::Key<'k>, Value: Serialize>(
+    pub fn emit_key_and_value<'k, Key: map::Key, Value: Serialize>(
         &self,
         key: Key,
         value: Value,

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -87,29 +87,29 @@ impl<'a> Document<'a> {
 
     /// Creates a `Map` result with an empty key and value.
     #[must_use]
-    pub fn emit(&self) -> Map<'static, (), ()> {
+    pub fn emit(&self) -> Map<(), ()> {
         self.emit_key_and_value((), ())
     }
 
     /// Creates a `Map` result with a `key` and an empty value.
     #[must_use]
-    pub fn emit_key<'k, Key: map::Key>(&self, key: Key) -> Map<'k, Key, ()> {
+    pub fn emit_key<Key: map::Key>(&self, key: Key) -> Map<Key, ()> {
         self.emit_key_and_value(key, ())
     }
 
     /// Creates a `Map` result with `value` and an empty key.
     #[must_use]
-    pub fn emit_value<Value: Serialize>(&self, value: Value) -> Map<'static, (), Value> {
+    pub fn emit_value<Value: Serialize>(&self, value: Value) -> Map<(), Value> {
         self.emit_key_and_value((), value)
     }
 
     /// Creates a `Map` result with a `key` and `value`.
     #[must_use]
-    pub fn emit_key_and_value<'k, Key: map::Key, Value: Serialize>(
+    pub fn emit_key_and_value<Key: map::Key, Value: Serialize>(
         &self,
         key: Key,
         value: Value,
-    ) -> Map<'k, Key, Value> {
+    ) -> Map<Key, Value> {
         Map::new(self.header.id, key, value)
     }
 

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -128,7 +128,7 @@ impl<'a> Document<'a> {
 fn emissions_tests() -> Result<(), crate::Error> {
     use crate::{
         schema::{Collection, Map},
-        test_util::{Basic, BasicCollection},
+        test_util::Basic,
     };
 
     let doc = Document::with_contents(
@@ -137,7 +137,7 @@ fn emissions_tests() -> Result<(), crate::Error> {
             value: String::default(),
             parent_id: None,
         },
-        BasicCollection::id(),
+        Basic::id(),
     )?;
 
     assert_eq!(doc.emit(), Map::new(doc.header.id, (), ()));

--- a/core/src/schema/collection.rs
+++ b/core/src/schema/collection.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, fmt::Display};
+use std::{
+    borrow::Cow,
+    fmt::{Debug, Display},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +10,7 @@ use crate::schema::Schema;
 /// A unique collection id. Choose collection names that aren't likely to
 /// conflict with others, so that if someone mixes collections from multiple
 /// authors in a single database.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
 pub struct Id(pub Cow<'static, str>);
 
 impl From<&'static str> for Id {
@@ -24,12 +27,12 @@ impl From<String> for Id {
 
 impl Display for Id {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        Display::fmt(&self.0, f)
     }
 }
 
 /// A namespaced collection of `Document<Self>` items and views.
-pub trait Collection: Send + Sync {
+pub trait Collection: Debug + Send + Sync {
     /// The `Id` of this collection.
     fn id() -> Id;
 

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -6,10 +6,8 @@ use std::{
 
 use crate::schema::{
     collection::{self, Collection},
-    View,
+    view, View,
 };
-
-use super::view;
 
 /// Defines a group of collections that are stored into a single database.
 pub trait Database: Send + Sync + Debug + 'static {
@@ -88,7 +86,7 @@ fn schema_tests() {
 
     assert_eq!(schema.collections.len(), 1);
     assert_eq!(schema.collections[&TypeId::of::<Basic>()], Basic::id());
-    assert_eq!(schema.views.len(), 2);
+    assert_eq!(schema.views.len(), 3);
     assert_eq!(
         schema.views[&TypeId::of::<BasicCount>()].name(),
         BasicCount.name()

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -77,16 +77,13 @@ where
 
 #[test]
 fn schema_tests() {
-    use crate::test_util::{BasicCollection, BasicCount, BasicDatabase};
+    use crate::test_util::{Basic, BasicCount, BasicDatabase};
     let mut schema = Schema::default();
     BasicDatabase::define_collections(&mut schema);
 
     assert_eq!(schema.collections.len(), 1);
-    assert_eq!(
-        schema.collections[&TypeId::of::<BasicCollection>()],
-        BasicCollection::id()
-    );
-    assert_eq!(schema.views.len(), 1);
+    assert_eq!(schema.collections[&TypeId::of::<Basic>()], Basic::id());
+    assert_eq!(schema.views.len(), 2);
     assert_eq!(
         schema.views[&TypeId::of::<BasicCount>()].name(),
         BasicCount.name()

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -2,6 +2,7 @@ use std::{
     any::{Any, TypeId},
     borrow::Cow,
     collections::HashMap,
+    fmt::Debug,
 };
 
 use crate::schema::{
@@ -10,7 +11,7 @@ use crate::schema::{
 };
 
 /// Defines a group of collections that are stored into a single database.
-pub trait Database: Send + Sync {
+pub trait Database: Send + Sync + Debug + 'static {
     /// Defines the `Collection`s into `schema`
     fn define_collections(schema: &mut Schema);
 }
@@ -20,7 +21,7 @@ trait ThreadsafeAny: Any + Send + Sync {}
 impl<T> ThreadsafeAny for T where T: Any + Send + Sync {}
 
 /// A collection of defined collections and views.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Schema {
     collections: HashMap<TypeId, collection::Id>,
     views: HashMap<TypeId, Cow<'static, str>>,

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -1,6 +1,5 @@
 use std::{
     any::{Any, TypeId},
-    borrow::Cow,
     collections::HashMap,
     fmt::Debug,
 };
@@ -9,6 +8,8 @@ use crate::schema::{
     collection::{self, Collection},
     View,
 };
+
+use super::view;
 
 /// Defines a group of collections that are stored into a single database.
 pub trait Database: Send + Sync + Debug + 'static {
@@ -24,7 +25,8 @@ impl<T> ThreadsafeAny for T where T: Any + Send + Sync {}
 #[derive(Default, Debug)]
 pub struct Schema {
     collections: HashMap<TypeId, collection::Id>,
-    views: HashMap<TypeId, Cow<'static, str>>,
+    views: HashMap<TypeId, Box<dyn view::Serialized>>,
+    views_by_name: HashMap<String, TypeId>,
 }
 
 impl Schema {
@@ -35,14 +37,26 @@ impl Schema {
     }
 
     /// Adds the view `V`.
-    pub fn define_view<'k, V: View<'k> + 'static>(&mut self) {
-        self.views.insert(TypeId::of::<V>(), V::name());
+    pub fn define_view<V: View + 'static>(&mut self, view: V) {
+        let name = view.name();
+        self.views.insert(TypeId::of::<V>(), Box::new(view));
+        self.views_by_name
+            .insert(name.to_string(), TypeId::of::<V>());
     }
 
     /// Returns `true` if this schema contains the collection `C`.
     #[must_use]
     pub fn contains<C: Collection + 'static>(&self) -> bool {
         self.collections.contains_key(&TypeId::of::<C>())
+    }
+
+    /// Returns `true` if this schema contains the collection `C`.
+    #[must_use]
+    pub fn view_by_name(&self, name: &str) -> Option<&'_ dyn view::Serialized> {
+        self.views_by_name
+            .get(name)
+            .and_then(|type_id| self.views.get(type_id))
+            .map(AsRef::as_ref)
     }
 }
 
@@ -68,7 +82,7 @@ fn schema_tests() {
     );
     assert_eq!(schema.views.len(), 1);
     assert_eq!(
-        schema.views[&TypeId::of::<BasicCount>()],
-        BasicCount::name()
+        schema.views[&TypeId::of::<BasicCount>()].name(),
+        BasicCount.name()
     );
 }

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -58,6 +58,12 @@ impl Schema {
             .and_then(|type_id| self.views.get(type_id))
             .map(AsRef::as_ref)
     }
+
+    /// Returns `true` if this schema contains the collection `C`.
+    #[must_use]
+    pub fn view<V: View + 'static>(&self) -> Option<&'_ dyn view::Serialized> {
+        self.views.get(&TypeId::of::<V>()).map(AsRef::as_ref)
+    }
 }
 
 impl<T> Database for T

--- a/core/src/schema/database.rs
+++ b/core/src/schema/database.rs
@@ -50,7 +50,7 @@ impl Schema {
         self.collections.contains_key(&TypeId::of::<C>())
     }
 
-    /// Returns `true` if this schema contains the collection `C`.
+    /// Looks up a [`view::Serialized`] by name.
     #[must_use]
     pub fn view_by_name(&self, name: &str) -> Option<&'_ dyn view::Serialized> {
         self.views_by_name
@@ -59,10 +59,15 @@ impl Schema {
             .map(AsRef::as_ref)
     }
 
-    /// Returns `true` if this schema contains the collection `C`.
+    /// Looks up a [`view::Serialized`] through the the type `V`.
     #[must_use]
     pub fn view<V: View + 'static>(&self) -> Option<&'_ dyn view::Serialized> {
         self.views.get(&TypeId::of::<V>()).map(AsRef::as_ref)
+    }
+
+    /// Iterates over all registered views.
+    pub fn views(&self) -> impl Iterator<Item = &'_ dyn view::Serialized> {
+        self.views.values().map(AsRef::as_ref)
     }
 }
 

--- a/core/src/schema/view.rs
+++ b/core/src/schema/view.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt::Debug};
 
 use serde::{Deserialize, Serialize};
 
-use crate::document::Document;
+use crate::{document::Document, schema::Collection};
 
 /// Types for defining a `Map` within a `View`.
 pub mod map;
@@ -31,7 +31,10 @@ pub type MapResult<K = (), V = ()> = Result<Option<Map<K, V>>, Error>;
 /// This implementation is under active development, our own docs explaining our
 /// implementation will be written as things are solidified.
 // TODO write our own view docs
-pub trait View: Send + Sync + Debug {
+pub trait View: Send + Sync + Debug + 'static {
+    /// The collection this view belongs to
+    type Collection: Collection;
+
     /// The key for this view.
     type MapKey: Key + 'static;
 
@@ -128,7 +131,7 @@ where
             Some(map) => Ok(Some(map::Serialized {
                 source: map.source,
                 key: map.key.as_big_endian_bytes().to_vec(),
-                value: serde_cbor::value::to_value(&map.value)?,
+                value: serde_cbor::to_vec(&map.value)?,
             })),
             None => Ok(None),
         }

--- a/core/src/schema/view.rs
+++ b/core/src/schema/view.rs
@@ -33,7 +33,7 @@ pub type MapResult<'k, K = (), V = ()> = Result<Option<Map<'k, K, V>>, Error>;
 // TODO write our own view docs
 pub trait View<'k> {
     /// The key for this view.
-    type MapKey: Key<'k> + 'static;
+    type MapKey: Key + 'static;
 
     /// An associated type that can be stored with each entry in the view.
     type MapValue: Serialize + for<'de> Deserialize<'de>;
@@ -117,7 +117,7 @@ where
         match map {
             Some(map) => Ok(Some(map::Serialized {
                 source: map.source,
-                key: map.key.into_big_endian_bytes(),
+                key: Cow::Owned(map.key.as_big_endian_bytes().to_vec()),
                 value: serde_cbor::value::to_value(&map.value)?,
             })),
             None => Ok(None),

--- a/core/src/schema/view.rs
+++ b/core/src/schema/view.rs
@@ -8,6 +8,8 @@ use crate::{document::Document, schema::Collection};
 pub mod map;
 pub use map::{Key, Map};
 
+use super::collection;
+
 /// Errors that arise when interacting with views.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -103,6 +105,8 @@ where
 
 /// Wraps a [`View`] with serialization to erase the associated types
 pub trait Serialized: Send + Sync + Debug {
+    /// Wraps [`View::collection`]
+    fn collection(&self) -> collection::Id;
     /// Wraps [`View::version`]
     fn version(&self) -> usize;
     /// Wraps [`View::name`]
@@ -116,6 +120,10 @@ where
     T: View,
     <T as View>::MapKey: 'static,
 {
+    fn collection(&self) -> collection::Id {
+        <<Self as View>::Collection as Collection>::id()
+    }
+
     fn version(&self) -> usize {
         self.version()
     }

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -1,10 +1,10 @@
-use std::{borrow::Cow, convert::TryInto, marker::PhantomData};
+use std::{borrow::Cow, convert::TryInto};
 
 use serde::{Deserialize, Serialize};
 
 /// A document's entry in a View's mappings.
 #[derive(PartialEq, Debug)]
-pub struct Map<'k, K: Key = (), V: Serialize = ()> {
+pub struct Map<K: Key = (), V: Serialize = ()> {
     /// The id of the document that emitted this entry.
     pub source: u64,
 
@@ -13,31 +13,23 @@ pub struct Map<'k, K: Key = (), V: Serialize = ()> {
 
     /// An associated value stored in the view.
     pub value: V,
-
-    _phantom: PhantomData<&'k K>,
 }
 
-impl<'k, K: Key, V: Serialize> Map<'k, K, V> {
+impl<K: Key, V: Serialize> Map<K, V> {
     /// Creates a new Map entry for the document with id `source`.
     pub fn new(source: u64, key: K, value: V) -> Self {
-        Self {
-            source,
-            key,
-            value,
-            _phantom: PhantomData::default(),
-        }
+        Self { source, key, value }
     }
 }
 
 /// Represents a document's entry in a View's mappings, serialized and ready to store.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Serialized<'k> {
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Serialized {
     /// The id of the document that emitted this entry.
     pub source: u64,
 
     /// The key used to index the View.
-    #[serde(borrow)]
-    pub key: Cow<'k, [u8]>,
+    pub key: Vec<u8>,
 
     /// An associated value stored in the view.
     pub value: serde_cbor::Value,

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -44,7 +44,7 @@ pub struct Serialized<'k> {
 }
 
 /// A trait that enables a type to convert itself to a big-endian/network byte order.
-pub trait Key<'k>: Send + Sync {
+pub trait Key<'k>: Clone + Send + Sync {
     /// Convert `self` into an `IVec` containing bytes ordered in big-endian/network byte order.
     fn into_big_endian_bytes(self) -> Cow<'k, [u8]>;
 

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -32,7 +32,7 @@ pub struct Serialized {
     pub key: Vec<u8>,
 
     /// An associated value stored in the view.
-    pub value: serde_cbor::Value,
+    pub value: Vec<u8>,
 }
 
 /// A trait that enables a type to convert itself to a big-endian/network byte order.

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -38,52 +38,54 @@ pub struct Serialized {
 /// A trait that enables a type to convert itself to a big-endian/network byte order.
 pub trait Key: Clone + Send + Sync {
     /// Convert `self` into an `IVec` containing bytes ordered in big-endian/network byte order.
-    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]>;
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>>;
 
     /// Convert a slice of bytes into `Self` by interpretting `bytes` in big-endian/network byte order.
-    fn from_big_endian_bytes(bytes: &[u8]) -> Self;
+    fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self>;
 }
 
 impl<'k> Key for Cow<'k, [u8]> {
-    fn as_big_endian_bytes(&self) -> Cow<'k, [u8]> {
-        self.clone()
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'k, [u8]>> {
+        Ok(self.clone())
     }
 
-    fn from_big_endian_bytes(bytes: &[u8]) -> Self {
-        Cow::Owned(bytes.to_vec())
+    fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        Ok(Cow::Owned(bytes.to_vec()))
     }
 }
 
 impl Key for String {
-    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.as_bytes())
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(self.as_bytes()))
     }
 
-    fn from_big_endian_bytes(bytes: &[u8]) -> Self {
-        Self::from_utf8(bytes.to_vec()).unwrap() // TODO this should be able to propogate an error
+    fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        Ok(Self::from_utf8(bytes.to_vec())?)
     }
 }
 
 impl Key for () {
-    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::default()
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::default())
     }
 
-    fn from_big_endian_bytes(_: &[u8]) -> Self {}
+    fn from_big_endian_bytes(_: &[u8]) -> anyhow::Result<Self> {
+        Ok(())
+    }
 }
 
 #[cfg(feature = "uuid")]
 impl<'k> Key for uuid::Uuid {
-    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
-        Cow::Borrowed(self.as_bytes())
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(self.as_bytes()))
     }
 
-    fn from_big_endian_bytes(bytes: &[u8]) -> Self {
-        Self::from_bytes(bytes.try_into().unwrap())
+    fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        Ok(Self::from_bytes(bytes.try_into()?))
     }
 }
 
-impl<'k, T> Key for Option<T>
+impl<T> Key for Option<T>
 where
     T: Key,
 {
@@ -93,21 +95,21 @@ where
     // TODO consider removing this panic limitation by adding a single byte to
     // each key (at the end preferrably) so that we can distinguish between None
     // and a 0-byte type
-    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
-        self.as_ref()
-            .map(|contents| {
-                let contents = contents.as_big_endian_bytes();
-                assert!(!contents.is_empty());
-                contents
-            })
-            .unwrap_or_default()
+    fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        if let Some(contents) = self {
+            let contents = contents.as_big_endian_bytes()?;
+            assert!(!contents.is_empty());
+            Ok(contents)
+        } else {
+            Ok(Cow::default())
+        }
     }
 
-    fn from_big_endian_bytes(bytes: &[u8]) -> Self {
+    fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
         if bytes.is_empty() {
-            None
+            Ok(None)
         } else {
-            Some(T::from_big_endian_bytes(bytes))
+            Ok(Some(T::from_big_endian_bytes(bytes)?))
         }
     }
 }
@@ -115,12 +117,12 @@ where
 macro_rules! impl_key_for_primitive {
     ($type:ident) => {
         impl Key for $type {
-            fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
-                Cow::from(self.to_be_bytes().to_vec())
+            fn as_big_endian_bytes(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+                Ok(Cow::from(self.to_be_bytes().to_vec()))
             }
 
-            fn from_big_endian_bytes(bytes: &[u8]) -> Self {
-                $type::from_be_bytes(bytes.try_into().unwrap())
+            fn from_big_endian_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+                Ok($type::from_be_bytes(bytes.try_into()?))
             }
         }
     };
@@ -139,20 +141,20 @@ impl_key_for_primitive!(u128);
 
 #[test]
 #[allow(clippy::cognitive_complexity)] // I disagree - @ecton
-fn primitive_key_encoding_tests() {
+fn primitive_key_encoding_tests() -> anyhow::Result<()> {
     macro_rules! test_primitive_extremes {
         ($type:ident) => {
             assert_eq!(
                 &$type::MAX.to_be_bytes(),
-                $type::MAX.as_big_endian_bytes().as_ref()
+                $type::MAX.as_big_endian_bytes()?.as_ref()
             );
             assert_eq!(
                 $type::MAX,
-                $type::from_big_endian_bytes(&$type::MAX.as_big_endian_bytes())
+                $type::from_big_endian_bytes(&$type::MAX.as_big_endian_bytes()?)?
             );
             assert_eq!(
                 $type::MIN,
-                $type::from_big_endian_bytes(&$type::MIN.as_big_endian_bytes())
+                $type::from_big_endian_bytes(&$type::MIN.as_big_endian_bytes()?)?
             );
         };
     }
@@ -167,30 +169,35 @@ fn primitive_key_encoding_tests() {
     test_primitive_extremes!(u64);
     test_primitive_extremes!(i128);
     test_primitive_extremes!(u128);
+
+    Ok(())
 }
 
 #[test]
-fn optional_key_encoding_tests() {
-    assert!(Option::<i8>::None.as_big_endian_bytes().is_empty());
+fn optional_key_encoding_tests() -> anyhow::Result<()> {
+    assert!(Option::<i8>::None.as_big_endian_bytes()?.is_empty());
     assert_eq!(
         Some(1_i8),
-        Option::from_big_endian_bytes(&Some(1_i8).as_big_endian_bytes())
+        Option::from_big_endian_bytes(&Some(1_i8).as_big_endian_bytes()?)?
     );
+    Ok(())
 }
 
 #[test]
 #[allow(clippy::unit_cmp)] // this is more of a compilation test
-fn unit_key_encoding_tests() {
-    assert!(().as_big_endian_bytes().is_empty());
-    assert_eq!((), <() as Key>::from_big_endian_bytes(&[]));
+fn unit_key_encoding_tests() -> anyhow::Result<()> {
+    assert!(().as_big_endian_bytes()?.is_empty());
+    assert_eq!((), <() as Key>::from_big_endian_bytes(&[])?);
+    Ok(())
 }
 
 #[test]
-fn vec_key_encoding_tests() {
+fn vec_key_encoding_tests() -> anyhow::Result<()> {
     const ORIGINAL_VALUE: &[u8] = b"pliantdb";
     let vec = Cow::<'_, [u8]>::from(ORIGINAL_VALUE);
     assert_eq!(
         vec.clone(),
-        Cow::from_big_endian_bytes(&vec.as_big_endian_bytes())
+        Cow::from_big_endian_bytes(&vec.as_big_endian_bytes()?)?
     );
+    Ok(())
 }

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -54,6 +54,16 @@ impl<'k> Key for Cow<'k, [u8]> {
     }
 }
 
+impl Key for String {
+    fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.as_bytes())
+    }
+
+    fn from_big_endian_bytes(bytes: &[u8]) -> Self {
+        Self::from_utf8(bytes.to_vec()).unwrap() // TODO this should be able to propogate an error
+    }
+}
+
 impl Key for () {
     fn as_big_endian_bytes(&self) -> Cow<'_, [u8]> {
         Cow::default()

--- a/core/src/schema/view/map.rs
+++ b/core/src/schema/view/map.rs
@@ -44,7 +44,7 @@ pub struct Serialized<'k> {
 }
 
 /// A trait that enables a type to convert itself to a big-endian/network byte order.
-pub trait Key<'k> {
+pub trait Key<'k>: Send + Sync {
     /// Convert `self` into an `IVec` containing bytes ordered in big-endian/network byte order.
     fn into_big_endian_bytes(self) -> Cow<'k, [u8]>;
 

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -183,3 +183,14 @@ impl AsRef<Path> for TestDirectory {
         &self.0
     }
 }
+
+#[derive(Debug)]
+pub struct BasicCollectionWithNoViews;
+
+impl Collection for BasicCollectionWithNoViews {
+    fn id() -> collection::Id {
+        Basic::id()
+    }
+
+    fn define_views(_schema: &mut Schema) {}
+}

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -49,6 +49,33 @@ impl<'k> View<'k> for BasicCount {
         Ok(mappings.iter().map(|map| map.value).sum())
     }
 }
+pub struct BasicByParentId;
+
+impl<'k> View<'k> for BasicByParentId {
+    type MapKey = Option<u64>;
+    type MapValue = usize;
+    type Reduce = usize;
+
+    fn version() -> usize {
+        0
+    }
+
+    fn name() -> Cow<'static, str> {
+        Cow::from("by-parent-id")
+    }
+
+    fn map(document: &Document<'_>) -> MapResult<'k, Self::MapKey, Self::MapValue> {
+        let contents = document.contents::<Basic>()?;
+        Ok(Some(document.emit_key_and_value(contents.parent_id, 1)))
+    }
+
+    fn reduce(
+        mappings: &[Map<'k, Self::MapKey, Self::MapValue>],
+        _rereduce: bool,
+    ) -> Result<Self::Reduce, view::Error> {
+        Ok(mappings.iter().map(|map| map.value).sum())
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
 pub struct Basic {

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -20,58 +20,63 @@ impl Collection for BasicCollection {
     }
 
     fn define_views(schema: &mut Schema) {
-        schema.define_view::<BasicCount>();
+        schema.define_view(BasicCount);
     }
 }
 
+#[derive(Debug)]
 pub struct BasicCount;
 
-impl<'k> View<'k> for BasicCount {
+impl View for BasicCount {
     type MapKey = ();
     type MapValue = usize;
     type Reduce = usize;
 
-    fn version() -> usize {
+    fn version(&self) -> usize {
         0
     }
 
-    fn name() -> Cow<'static, str> {
+    fn name(&self) -> Cow<'static, str> {
         Cow::from("count")
     }
 
-    fn map(document: &Document<'_>) -> MapResult<'k, Self::MapKey, Self::MapValue> {
+    fn map(&self, document: &Document<'_>) -> MapResult<Self::MapKey, Self::MapValue> {
         Ok(Some(document.emit_key_and_value((), 1)))
     }
 
     fn reduce(
-        mappings: &[Map<'k, Self::MapKey, Self::MapValue>],
+        &self,
+        mappings: &[Map<Self::MapKey, Self::MapValue>],
         _rereduce: bool,
     ) -> Result<Self::Reduce, view::Error> {
         Ok(mappings.iter().map(|map| map.value).sum())
     }
 }
+
+#[derive(Debug)]
 pub struct BasicByParentId;
 
-impl<'k> View<'k> for BasicByParentId {
+impl View for BasicByParentId {
     type MapKey = Option<u64>;
     type MapValue = usize;
     type Reduce = usize;
 
-    fn version() -> usize {
+    fn version(&self) -> usize {
         0
     }
 
-    fn name() -> Cow<'static, str> {
+    fn name(&self) -> Cow<'static, str> {
         Cow::from("by-parent-id")
     }
 
-    fn map(document: &Document<'_>) -> MapResult<'k, Self::MapKey, Self::MapValue> {
+    fn map(&self, document: &Document<'_>) -> MapResult<Self::MapKey, Self::MapValue> {
         let contents = document.contents::<Basic>()?;
         Ok(Some(document.emit_key_and_value(contents.parent_id, 1)))
     }
 
     fn reduce(
-        mappings: &[Map<'k, Self::MapKey, Self::MapValue>],
+        &self,
+        mappings: &[Map<Self::MapKey, Self::MapValue>],
         _rereduce: bool,
     ) -> Result<Self::Reduce, view::Error> {
         Ok(mappings.iter().map(|map| map.value).sum())

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -11,16 +11,14 @@ use crate::{
     schema::{collection, view, Collection, Database, MapResult, Schema, View},
 };
 
-#[derive(Debug)]
-pub struct BasicCollection;
-
-impl Collection for BasicCollection {
+impl Collection for Basic {
     fn id() -> collection::Id {
         collection::Id::from("tests.basic")
     }
 
     fn define_views(schema: &mut Schema) {
         schema.define_view(BasicCount);
+        schema.define_view(BasicByParentId);
     }
 }
 
@@ -28,6 +26,7 @@ impl Collection for BasicCollection {
 pub struct BasicCount;
 
 impl View for BasicCount {
+    type Collection = Basic;
     type MapKey = ();
     type MapValue = usize;
     type Reduce = usize;
@@ -57,6 +56,7 @@ impl View for BasicCount {
 pub struct BasicByParentId;
 
 impl View for BasicByParentId {
+    type Collection = Basic;
     type MapKey = Option<u64>;
     type MapValue = usize;
     type Reduce = usize;
@@ -94,7 +94,7 @@ pub struct BasicDatabase;
 
 impl Database for BasicDatabase {
     fn define_collections(schema: &mut Schema) {
-        schema.define_collection::<BasicCollection>();
+        schema.define_collection::<Basic>();
     }
 }
 

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -194,3 +194,14 @@ impl Collection for BasicCollectionWithNoViews {
 
     fn define_views(_schema: &mut Schema) {}
 }
+
+#[derive(Debug)]
+pub struct UnassociatedCollection;
+
+impl Collection for UnassociatedCollection {
+    fn id() -> collection::Id {
+        collection::Id::from("unassociated")
+    }
+
+    fn define_views(_schema: &mut Schema) {}
+}

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    io::ErrorKind,
     path::{Path, PathBuf},
 };
 
@@ -173,7 +174,9 @@ impl TestDirectory {
 impl Drop for TestDirectory {
     fn drop(&mut self) {
         if let Err(err) = std::fs::remove_dir_all(&self.0) {
-            eprintln!("Failed to clean up temporary folder: {:?}", err);
+            if err.kind() != ErrorKind::NotFound {
+                eprintln!("Failed to clean up temporary folder: {:?}", err);
+            }
         }
     }
 }

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -11,6 +11,7 @@ use crate::{
     schema::{collection, view, Collection, Database, MapResult, Schema, View},
 };
 
+#[derive(Debug)]
 pub struct BasicCollection;
 
 impl Collection for BasicCollection {
@@ -83,6 +84,7 @@ pub struct Basic {
     pub parent_id: Option<u64>,
 }
 
+#[derive(Debug)]
 pub struct BasicDatabase;
 
 impl Database for BasicDatabase {

--- a/jobs/Cargo.toml
+++ b/jobs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pliantdb-local"
+name = "pliantdb-jobs"
 version = "0.1.0-dev-0"
 authors = ["Jonathan Johnson <jon@khonsulabs.com>"]
 edition = "2018"
@@ -10,17 +10,12 @@ keywords = ["document-database", "database"]
 categories = ["database-implementations", "database"]
 readme = "../README.md"
 
-[dependencies]
-async-trait = "0.1"
-pliantdb-core = { path = "../core" }
-sled = "0.34"
-thiserror = "1"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_cbor = "0.11"
-bincode = "1.3"
-anyhow = "1"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dev-dependencies]
-pliantdb-core = { path = "../core", features = ["test-util"] }
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+async-trait = "0.1"
+flume = "0.10"
 futures = "0.3"
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"

--- a/jobs/Cargo.toml
+++ b/jobs/Cargo.toml
@@ -10,8 +10,6 @@ keywords = ["document-database", "database"]
 categories = ["database-implementations", "database"]
 readme = "../README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"

--- a/jobs/src/lib.rs
+++ b/jobs/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 #![warn(
     clippy::cargo,
-    missing_docs, 
+    missing_docs,
     // clippy::missing_docs_in_private_items,
     clippy::nursery,
     clippy::pedantic,

--- a/jobs/src/lib.rs
+++ b/jobs/src/lib.rs
@@ -1,7 +1,9 @@
+//! Aysnc jobs management for `PliantDB`.
+
 #![forbid(unsafe_code)]
 #![warn(
     clippy::cargo,
-    // TODO missing_docs, 
+    missing_docs, 
     // clippy::missing_docs_in_private_items,
     clippy::nursery,
     clippy::pedantic,
@@ -15,8 +17,10 @@
     clippy::option_if_let_else,
 )]
 
+/// Types related to the job [`Manager`].
 pub mod manager;
+/// Types related to defining [`Job`]s.
 pub mod task;
 mod traits;
 
-pub use self::traits::{Job, Keyed, Service};
+pub use self::traits::{Job, Keyed};

--- a/jobs/src/lib.rs
+++ b/jobs/src/lib.rs
@@ -1,9 +1,7 @@
-//! Local storage backend for `PliantDB`.
-
 #![forbid(unsafe_code)]
 #![warn(
     clippy::cargo,
-    missing_docs,
+    // TODO missing_docs, 
     // clippy::missing_docs_in_private_items,
     clippy::nursery,
     clippy::pedantic,
@@ -17,16 +15,8 @@
     clippy::option_if_let_else,
 )]
 
-mod error;
-mod open_trees;
-mod storage;
-#[doc(inline)]
-pub use pliantdb_core as core;
+pub mod manager;
+pub mod task;
+mod traits;
 
-pub use self::{
-    error::Error,
-    storage::{Storage, LIST_TRANSACTIONS_DEFAULT_RESULT_COUNT, LIST_TRANSACTIONS_MAX_RESULTS},
-};
-
-#[cfg(test)]
-mod tests;
+pub use self::traits::{Job, Keyed, Service};

--- a/jobs/src/manager.rs
+++ b/jobs/src/manager.rs
@@ -15,7 +15,7 @@ pub(crate) use managed_job::ManagedJob;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Manager<Key = ()> {
     pub(crate) jobs: Arc<RwLock<jobs::Jobs<Key>>>,
 }
@@ -27,6 +27,14 @@ where
     fn default() -> Self {
         Self {
             jobs: Arc::new(RwLock::new(jobs::Jobs::new())),
+        }
+    }
+}
+
+impl<Key> Clone for Manager<Key> {
+    fn clone(&self) -> Self {
+        Self {
+            jobs: self.jobs.clone(),
         }
     }
 }

--- a/jobs/src/manager.rs
+++ b/jobs/src/manager.rs
@@ -1,0 +1,75 @@
+use std::{fmt::Debug, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::{
+    task::{Handle, Id},
+    Job, Keyed,
+};
+
+pub(crate) mod jobs;
+mod managed_job;
+pub(crate) use managed_job::ManagedJob;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug, Clone)]
+pub struct Manager<Key = ()> {
+    pub(crate) jobs: Arc<RwLock<jobs::Jobs<Key>>>,
+}
+
+impl<Key> Default for Manager<Key>
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    fn default() -> Self {
+        Self {
+            jobs: Arc::new(RwLock::new(jobs::Jobs::new())),
+        }
+    }
+}
+
+impl<Key> Manager<Key>
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    pub async fn enqueue<J: Job + 'static>(&self, job: J) -> Handle<J::Output, Key> {
+        let mut jobs = self.jobs.write().await;
+        jobs.enqueue(job, None, self.clone())
+    }
+
+    pub async fn lookup_or_enqueue<J: Keyed<Key>>(
+        &self,
+        job: J,
+    ) -> Handle<<J as Job>::Output, Key> {
+        let mut jobs = self.jobs.write().await;
+        jobs.lookup_or_enqueue(job, self.clone())
+    }
+
+    pub async fn job_completed<T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static>(
+        &self,
+        id: Id,
+        key: Option<&Key>,
+        result: Result<T, anyhow::Error>,
+    ) {
+        let mut jobs = self.jobs.write().await;
+        jobs.job_completed(id, key, result).await
+    }
+
+    pub fn spawn_worker(&self) {
+        let manager = self.clone();
+        tokio::spawn(async move { manager.execute_jobs().await });
+    }
+
+    async fn execute_jobs(&self) {
+        let receiver = {
+            let jobs = self.jobs.read().await;
+            jobs.queue()
+        };
+        while let Ok(mut job) = receiver.recv_async().await {
+            job.execute().await
+        }
+    }
+}

--- a/jobs/src/manager/jobs.rs
+++ b/jobs/src/manager/jobs.rs
@@ -1,0 +1,132 @@
+use std::{any::Any, collections::HashMap, fmt::Debug, sync::Arc};
+
+use flume::{Receiver, Sender};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    manager::{ManagedJob, Manager},
+    task::{Handle, Id},
+    traits::Executable,
+    Job, Keyed,
+};
+
+#[derive(Debug)]
+pub struct Jobs<Key> {
+    last_task_id: u64,
+    result_senders: HashMap<Id, Vec<Box<dyn AnySender>>>,
+    keyed_jobs: HashMap<Key, Id>,
+    queuer: Sender<Box<dyn Executable>>,
+    queue: Receiver<Box<dyn Executable>>,
+}
+
+impl<Key> Jobs<Key>
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    pub fn new() -> Self {
+        let (queuer, queue) = flume::unbounded();
+
+        Self {
+            last_task_id: 0,
+            result_senders: HashMap::new(),
+            keyed_jobs: HashMap::new(),
+            queuer,
+            queue,
+        }
+    }
+
+    pub fn queue(&self) -> Receiver<Box<dyn Executable>> {
+        self.queue.clone()
+    }
+
+    pub fn enqueue<J: Job + 'static>(
+        &mut self,
+        job: J,
+        key: Option<Key>,
+        manager: Manager<Key>,
+    ) -> Handle<J::Output, Key> {
+        self.last_task_id = self.last_task_id.wrapping_add(1);
+        let id = Id(self.last_task_id);
+        self.queuer
+            .send(Box::new(ManagedJob {
+                id,
+                job,
+                key,
+                manager: manager.clone(),
+            }))
+            .unwrap();
+
+        self.create_new_task_handle(id, manager)
+    }
+
+    pub fn create_new_task_handle<
+        T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+    >(
+        &mut self,
+        id: Id,
+        manager: Manager<Key>,
+    ) -> Handle<T, Key> {
+        let (sender, receiver) = flume::bounded(1);
+        let senders = self.result_senders.entry(id).or_insert_with(Vec::default);
+        senders.push(Box::new(sender));
+
+        Handle {
+            id,
+            manager,
+            receiver,
+        }
+    }
+
+    pub fn lookup_or_enqueue<J: Keyed<Key>>(
+        &mut self,
+        job: J,
+        manager: Manager<Key>,
+    ) -> Handle<<J as Job>::Output, Key> {
+        if let Some(&id) = self.keyed_jobs.get(job.key()) {
+            self.create_new_task_handle(id, manager)
+        } else {
+            let key = job.key().clone();
+            let handle = self.enqueue(job, Some(key.clone()), manager);
+            self.keyed_jobs.insert(key, handle.id);
+            handle
+        }
+    }
+
+    pub async fn job_completed<T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static>(
+        &mut self,
+        id: Id,
+        key: Option<&Key>,
+        result: Result<T, anyhow::Error>,
+    ) {
+        if let Some(senders) = self.result_senders.remove(&id) {
+            tokio::spawn(async move {
+                let result = &Arc::new(result);
+                futures::future::join_all(senders.into_iter().map(|handle| async move {
+                    let handle = handle
+                        .as_any()
+                        .downcast_ref::<Sender<Arc<Result<T, anyhow::Error>>>>()
+                        .unwrap();
+                    handle.send_async(result.clone()).await
+                }))
+                .await;
+            });
+        }
+
+        if let Some(key) = key {
+            self.keyed_jobs.remove(key);
+        }
+    }
+}
+
+pub trait AnySender: Any + Send + Sync + Debug {
+    fn as_any(&self) -> &'_ dyn Any;
+}
+
+impl<T> AnySender for Sender<Arc<Result<T, anyhow::Error>>>
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &'_ dyn Any {
+        self
+    }
+}

--- a/jobs/src/manager/jobs.rs
+++ b/jobs/src/manager/jobs.rs
@@ -82,10 +82,10 @@ where
         job: J,
         manager: Manager<Key>,
     ) -> Handle<<J as Job>::Output, Key> {
-        if let Some(&id) = self.keyed_jobs.get(job.key().as_ref()) {
+        let key = job.key();
+        if let Some(&id) = self.keyed_jobs.get(&key) {
             self.create_new_task_handle(id, manager)
         } else {
-            let key = job.key().as_ref().clone();
             let handle = self.enqueue(job, Some(key.clone()), manager);
             self.keyed_jobs.insert(key, handle.id);
             handle

--- a/jobs/src/manager/jobs.rs
+++ b/jobs/src/manager/jobs.rs
@@ -82,10 +82,10 @@ where
         job: J,
         manager: Manager<Key>,
     ) -> Handle<<J as Job>::Output, Key> {
-        if let Some(&id) = self.keyed_jobs.get(job.key()) {
+        if let Some(&id) = self.keyed_jobs.get(job.key().as_ref()) {
             self.create_new_task_handle(id, manager)
         } else {
-            let key = job.key().clone();
+            let key = job.key().as_ref().clone();
             let handle = self.enqueue(job, Some(key.clone()), manager);
             self.keyed_jobs.insert(key, handle.id);
             handle

--- a/jobs/src/manager/managed_job.rs
+++ b/jobs/src/manager/managed_job.rs
@@ -1,0 +1,26 @@
+use crate::{manager::Manager, task::Id, traits::Executable, Job};
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub struct ManagedJob<J, Key> {
+    pub id: Id,
+    pub job: J,
+    pub manager: Manager<Key>,
+    pub key: Option<Key>,
+}
+
+#[async_trait]
+impl<J, Key> Executable for ManagedJob<J, Key>
+where
+    J: Job,
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    async fn execute(&mut self) {
+        let result = self.job.execute().await;
+
+        self.manager
+            .job_completed(self.id, self.key.as_ref(), result)
+            .await;
+    }
+}

--- a/jobs/src/manager/managed_job.rs
+++ b/jobs/src/manager/managed_job.rs
@@ -1,6 +1,8 @@
-use crate::{manager::Manager, task::Id, traits::Executable, Job};
-use async_trait::async_trait;
 use std::fmt::Debug;
+
+use async_trait::async_trait;
+
+use crate::{manager::Manager, task::Id, traits::Executable, Job};
 
 #[derive(Debug)]
 pub struct ManagedJob<J, Key> {

--- a/jobs/src/manager/tests.rs
+++ b/jobs/src/manager/tests.rs
@@ -1,0 +1,58 @@
+use crate::{Job, Keyed};
+use async_trait::async_trait;
+
+use super::Manager;
+
+#[derive(Debug)]
+struct TestJob(usize);
+
+#[async_trait]
+impl Job for TestJob {
+    type Output = usize;
+
+    async fn execute(&mut self) -> anyhow::Result<Self::Output> {
+        Ok(self.0)
+    }
+}
+
+impl Keyed<usize> for TestJob {
+    fn key(&self) -> &'_ usize {
+        &self.0
+    }
+}
+
+#[tokio::test]
+async fn simple() -> Result<(), flume::RecvError> {
+    let manager = Manager::<usize>::default();
+    manager.spawn_worker();
+    let handle = manager.enqueue(TestJob(1)).await;
+    if let Ok(value) = handle.receive().await?.as_ref() {
+        assert_eq!(value, &1);
+
+        Ok(())
+    } else {
+        unreachable!()
+    }
+}
+
+#[tokio::test]
+async fn keyed_simple() -> Result<(), flume::RecvError> {
+    let manager = Manager::<usize>::default();
+    let handle = manager.lookup_or_enqueue(TestJob(1)).await;
+    let handle2 = manager.lookup_or_enqueue(TestJob(1)).await;
+    assert_eq!(handle.id, handle2.id);
+    manager.spawn_worker();
+    let (result1, result2) = tokio::try_join!(handle.receive(), handle2.receive())?;
+
+    for result in vec![result1, result2] {
+        result
+            .as_ref()
+            .as_ref()
+            .map(|value| {
+                assert_eq!(value, &1);
+            })
+            .unwrap();
+    }
+
+    Ok(())
+}

--- a/jobs/src/manager/tests.rs
+++ b/jobs/src/manager/tests.rs
@@ -1,11 +1,10 @@
-use flume::TryRecvError;
-use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, hash::Hash, time::Duration};
+use std::{fmt::Debug, hash::Hash};
 
-use crate::{Job, Keyed};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 
 use super::Manager;
+use crate::{Job, Keyed};
 
 #[derive(Debug)]
 struct Echo<T>(T);

--- a/jobs/src/manager/tests.rs
+++ b/jobs/src/manager/tests.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::{Job, Keyed};
 use async_trait::async_trait;
 
@@ -18,8 +16,8 @@ impl Job for TestJob {
 }
 
 impl Keyed<usize> for TestJob {
-    fn key(&self) -> Cow<'_, usize> {
-        Cow::Borrowed(&self.0)
+    fn key(&self) -> usize {
+        self.0
     }
 }
 

--- a/jobs/src/manager/tests.rs
+++ b/jobs/src/manager/tests.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{Job, Keyed};
 use async_trait::async_trait;
 
@@ -16,8 +18,8 @@ impl Job for TestJob {
 }
 
 impl Keyed<usize> for TestJob {
-    fn key(&self) -> &'_ usize {
-        &self.0
+    fn key(&self) -> Cow<'_, usize> {
+        Cow::Borrowed(&self.0)
     }
 }
 

--- a/jobs/src/task.rs
+++ b/jobs/src/task.rs
@@ -5,12 +5,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::manager::Manager;
 
+/// he `Id` of an executing task.
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
 pub struct Id(pub(crate) u64);
 
+/// References a background task.
 #[derive(Debug)]
 pub struct Handle<T, Key> {
+    /// The task's id.
     pub id: Id,
+
     pub(crate) manager: Manager<Key>,
     pub(crate) receiver: Receiver<Arc<Result<T, anyhow::Error>>>,
 }
@@ -20,15 +24,20 @@ where
     T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
     Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
 {
+    /// Returns a copy of this handle. When the job is completed, both handles
+    /// will be able to `receive()` the results.
     pub async fn clone(&self) -> Self {
         let mut jobs = self.manager.jobs.write().await;
         jobs.create_new_task_handle(self.id, self.manager.clone())
     }
 
+    /// Waits for the job to complete and returns the result.
     pub async fn receive(&self) -> Result<Arc<Result<T, anyhow::Error>>, flume::RecvError> {
         self.receiver.recv_async().await
     }
 
+    /// Tries to receive the status of the job. If available, it is returned.
+    /// This function will not block.
     pub fn try_receive(&self) -> Result<Arc<Result<T, anyhow::Error>>, flume::TryRecvError> {
         self.receiver.try_recv()
     }

--- a/jobs/src/task.rs
+++ b/jobs/src/task.rs
@@ -1,0 +1,35 @@
+use std::{fmt::Debug, sync::Arc};
+
+use flume::Receiver;
+use serde::{Deserialize, Serialize};
+
+use crate::manager::Manager;
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+pub struct Id(pub(crate) u64);
+
+#[derive(Debug)]
+pub struct Handle<T, Key> {
+    pub id: Id,
+    pub(crate) manager: Manager<Key>,
+    pub(crate) receiver: Receiver<Arc<Result<T, anyhow::Error>>>,
+}
+
+impl<T, Key> Handle<T, Key>
+where
+    T: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    pub async fn clone(&self) -> Self {
+        let mut jobs = self.manager.jobs.write().await;
+        jobs.create_new_task_handle(self.id, self.manager.clone())
+    }
+
+    pub async fn receive(&self) -> Result<Arc<Result<T, anyhow::Error>>, flume::RecvError> {
+        self.receiver.recv_async().await
+    }
+
+    pub fn try_receive(&self) -> Result<Arc<Result<T, anyhow::Error>>, flume::TryRecvError> {
+        self.receiver.try_recv()
+    }
+}

--- a/jobs/src/traits.rs
+++ b/jobs/src/traits.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Debug};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ pub trait Keyed<Key>: Job
 where
     Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
 {
-    fn key(&self) -> Cow<'_, Key>;
+    fn key(&self) -> Key;
 }
 
 #[async_trait]

--- a/jobs/src/traits.rs
+++ b/jobs/src/traits.rs
@@ -1,0 +1,35 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::task::Handle;
+
+pub trait Service<Key>
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    fn enqueue<J: Job>(job: J) -> Handle<J::Output, Key>;
+    fn lookup_or_enqueue<J>(job: J) -> Handle<<J as Job>::Output, Key>
+    where
+        J: Keyed<Key>;
+}
+
+#[async_trait]
+pub trait Job: Debug + Send + Sync + 'static {
+    type Output: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static;
+
+    async fn execute(&mut self) -> anyhow::Result<Self::Output>;
+}
+
+pub trait Keyed<Key>: Job
+where
+    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
+{
+    fn key(&self) -> &'_ Key;
+}
+
+#[async_trait]
+pub trait Executable: Send + Sync + Debug {
+    async fn execute(&mut self);
+}

--- a/jobs/src/traits.rs
+++ b/jobs/src/traits.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ pub trait Keyed<Key>: Job
 where
     Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
 {
-    fn key(&self) -> &'_ Key;
+    fn key(&self) -> Cow<'_, Key>;
 }
 
 #[async_trait]

--- a/jobs/src/traits.rs
+++ b/jobs/src/traits.rs
@@ -3,29 +3,22 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::task::Handle;
-
-pub trait Service<Key>
-where
-    Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
-{
-    fn enqueue<J: Job>(job: J) -> Handle<J::Output, Key>;
-    fn lookup_or_enqueue<J>(job: J) -> Handle<<J as Job>::Output, Key>
-    where
-        J: Keyed<Key>;
-}
-
+/// Defines a background job that can be queued and executed.
 #[async_trait]
 pub trait Job: Debug + Send + Sync + 'static {
+    /// The output type of the job.
     type Output: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static;
 
+    /// Executes the job and returns the result.
     async fn execute(&mut self) -> anyhow::Result<Self::Output>;
 }
 
+/// Defines a background job that has a unique `key`.
 pub trait Keyed<Key>: Job
 where
     Key: Clone + std::hash::Hash + Eq + Send + Sync + Debug + 'static,
 {
+    /// The unique `key` for this `Job`
     fn key(&self) -> Key;
 }
 

--- a/local/Cargo.toml
+++ b/local/Cargo.toml
@@ -21,6 +21,7 @@ serde_cbor = "0.11"
 bincode = "1.3"
 anyhow = "1"
 pliantdb-jobs = { path = "../jobs" }
+flume = "0.10"
 
 [dev-dependencies]
 pliantdb-core = { path = "../core", features = ["test-util"] }

--- a/local/Cargo.toml
+++ b/local/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_cbor = "0.11"
 bincode = "1.3"
 anyhow = "1"
+pliantdb-jobs = { path = "../jobs" }
 
 [dev-dependencies]
 pliantdb-core = { path = "../core", features = ["test-util"] }

--- a/local/benches/basics.rs
+++ b/local/benches/basics.rs
@@ -38,9 +38,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     // First set of benchmarks tests inserting documents
     let mut group = c.benchmark_group("save_documents");
     for size in [KB, 2 * KB, 8 * KB, 32 * KB, KB * KB].iter() {
-        let path = TestDirectory::new("benches-basics");
+        let path = TestDirectory::new(format!("benches-basics-{}.pliantdb", size));
         let db = runtime
-            .block_on(Storage::open_local(path, &Configuration::default()))
+            .block_on(Storage::open_local(&path, &Configuration::default()))
             .unwrap();
         let mut data = Vec::with_capacity(*size);
         data.resize_with(*size, || 7u8);

--- a/local/src/config.rs
+++ b/local/src/config.rs
@@ -1,0 +1,46 @@
+/// Configuration options for [`Storage`].
+#[derive(Default, Debug)]
+pub struct Configuration {
+    /// Configuration options related to background tasks.
+    pub workers: Tasks,
+
+    /// Configuration options related to views.
+    pub views: Views,
+}
+
+/// Configujration options for background tasks.
+#[derive(Debug)]
+pub struct Tasks {
+    /// Defines how many workers should be spawned to process tasks. Default
+    /// value is `16`.
+    pub worker_count: usize,
+}
+
+impl Default for Tasks {
+    fn default() -> Self {
+        Self {
+            // TODO this was arbitrarily picked, it probably should be higher,
+            // but it also should probably be based on the cpu's capabilities
+            worker_count: 16,
+        }
+    }
+}
+
+/// Configuration options for views.
+#[derive(Debug)]
+pub struct Views {
+    /// If true, the database will scan all views during the call to
+    /// `open_local`. This will cause database opening to take longer, but once
+    /// the database is open, no request will need to wait for the integrity to
+    /// be checked. However, for faster startup time, you may wish to delay the
+    /// integrity scan. Default value is `false`.
+    pub check_integrity_on_open: bool,
+}
+
+impl Default for Views {
+    fn default() -> Self {
+        Self {
+            check_integrity_on_open: false,
+        }
+    }
+}

--- a/local/src/error.rs
+++ b/local/src/error.rs
@@ -12,6 +12,10 @@ pub enum Error {
     /// An error occurred serializing the contents of a `Document` or results of a `View`.
     #[error("error while serializing: {0}")]
     Serialization(#[from] serde_cbor::Error),
+
+    /// An internal error occurred while waiting for a message.
+    #[error("error while waiting for a message: {0}")]
+    InternalCommunication(#[from] flume::RecvError),
 }
 
 impl Into<pliantdb_core::Error> for Error {

--- a/local/src/error.rs
+++ b/local/src/error.rs
@@ -1,3 +1,5 @@
+use pliantdb_core::schema::view;
+
 /// Errors that can occur from interacting with storage.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -16,6 +18,10 @@ pub enum Error {
     /// An internal error occurred while waiting for a message.
     #[error("error while waiting for a message: {0}")]
     InternalCommunication(#[from] flume::RecvError),
+
+    /// An internal error occurred while waiting for a message.
+    #[error("error while waiting for a message: {0}")]
+    View(#[from] view::Error),
 }
 
 impl Into<pliantdb_core::Error> for Error {

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -20,6 +20,7 @@
 mod error;
 mod open_trees;
 mod storage;
+mod tasks;
 mod views;
 
 #[doc(inline)]

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -17,6 +17,8 @@
     clippy::option_if_let_else,
 )]
 
+/// Configuration options.
+pub mod config;
 mod error;
 mod open_trees;
 mod storage;
@@ -27,6 +29,7 @@ mod views;
 pub use pliantdb_core as core;
 
 pub use self::{
+    config::Configuration,
     error::Error,
     storage::{Storage, LIST_TRANSACTIONS_DEFAULT_RESULT_COUNT, LIST_TRANSACTIONS_MAX_RESULTS},
 };

--- a/local/src/lib.rs
+++ b/local/src/lib.rs
@@ -20,6 +20,8 @@
 mod error;
 mod open_trees;
 mod storage;
+mod views;
+
 #[doc(inline)]
 pub use pliantdb_core as core;
 

--- a/local/src/storage.rs
+++ b/local/src/storage.rs
@@ -296,7 +296,10 @@ where
         Self: Sized,
     {
         let View { key, .. } = query;
-        let view = self.schema.view::<V>().unwrap();
+        let view = self
+            .schema
+            .view::<V>()
+            .expect("query made with view that isn't registered with this database");
         self.tasks
             .update_view_if_needed(view, self)
             .await

--- a/local/src/storage.rs
+++ b/local/src/storage.rs
@@ -2,9 +2,9 @@ use std::{borrow::Cow, collections::HashMap, marker::PhantomData, path::Path, sy
 
 use async_trait::async_trait;
 use pliantdb_core::{
-    connection::{Collection, Connection},
+    connection::{Collection, Connection, View},
     document::{Document, Header},
-    schema::{self, collection, Database, Key, Schema},
+    schema::{self, collection, map, Database, Key, Schema},
     transaction::{self, ChangedDocument, Command, Operation, OperationResult, Transaction},
 };
 use sled::{
@@ -226,6 +226,17 @@ where
             // an error, but technically this is a correct response.
             Ok(Vec::default())
         }
+    }
+
+    #[must_use]
+    async fn query<'k, V: schema::View<'k>>(
+        &self,
+        query: View<'a, 'k, Self, V>,
+    ) -> Result<Vec<map::Serialized<'static>>, pliantdb_core::Error>
+    where
+        Self: Sized,
+    {
+        todo!()
     }
 }
 

--- a/local/src/tasks.rs
+++ b/local/src/tasks.rs
@@ -111,4 +111,15 @@ impl TaskManager {
 
         Ok(None)
     }
+
+    pub async fn mark_integrity_check_complete(
+        &self,
+        collection: collection::Id,
+        view_name: Cow<'static, str>,
+    ) {
+        let mut statuses = self.statuses.write().await;
+        statuses
+            .completed_integrity_checks
+            .insert((collection, view_name));
+    }
 }

--- a/local/src/tasks.rs
+++ b/local/src/tasks.rs
@@ -1,0 +1,102 @@
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
+
+use pliantdb_core::schema::{collection, view, Database};
+use pliantdb_jobs::manager::Manager;
+use tokio::sync::RwLock;
+
+use crate::{
+    views::{
+        integrity_scanner::{IntegrityScan, IntegrityScanner},
+        mapper::{Map, Mapper},
+        view_invalidated_docs_tree_name, Task,
+    },
+    Storage,
+};
+
+#[derive(Debug, Clone)]
+pub struct TaskManager {
+    pub jobs: Manager<Task>,
+    statuses: Arc<RwLock<Statuses>>,
+}
+
+#[derive(Default, Debug)]
+pub struct Statuses {
+    completed_integrity_checks: HashSet<(collection::Id, Cow<'static, str>)>,
+}
+
+impl TaskManager {
+    pub fn new(jobs: Manager<Task>) -> Self {
+        Self {
+            jobs,
+            statuses: Arc::default(),
+        }
+    }
+
+    pub async fn update_view_if_needed<DB: Database>(
+        &self,
+        collection: collection::Id,
+        view: &dyn view::Serialized,
+        storage: &Storage<DB>,
+    ) -> Result<(), crate::Error> {
+        let view_name = view.name();
+        if !self
+            .view_integrity_checked(collection.clone(), view_name.clone())
+            .await
+        {
+            let job = self
+                .jobs
+                .lookup_or_enqueue(IntegrityScanner {
+                    storage: storage.clone(),
+                    scan: IntegrityScan {
+                        view_version: view.version(),
+                        collection: collection.clone(),
+                        view_name: view_name.clone(),
+                    },
+                })
+                .await;
+            job.receive().await.unwrap();
+        }
+
+        let needs_reindex = tokio::task::block_in_place(|| {
+            let invalidated_docs = storage.sled.open_tree(view_invalidated_docs_tree_name(
+                &collection,
+                view_name.as_ref(),
+            ));
+            invalidated_docs.iter().next().is_some()
+        });
+
+        if needs_reindex {
+            let wait_for_transaction = storage.last_transaction_id().await?.unwrap();
+            loop {
+                let job = self
+                    .jobs
+                    .lookup_or_enqueue(Mapper {
+                        storage: storage.clone(),
+                        map: Map {
+                            collection: collection.clone(),
+                            view_name: view_name.clone(),
+                        },
+                    })
+                    .await;
+                if let Ok(id) = job.receive().await?.as_ref() {
+                    if wait_for_transaction <= *id {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn view_integrity_checked(
+        &self,
+        collection: collection::Id,
+        view_name: Cow<'static, str>,
+    ) -> bool {
+        let statuses = self.statuses.read().await;
+        statuses
+            .completed_integrity_checks
+            .contains(&(collection.clone(), view_name))
+    }
+}

--- a/local/src/tests.rs
+++ b/local/src/tests.rs
@@ -2,7 +2,7 @@ use pliantdb_core::{
     connection::Connection,
     document::Document,
     schema::Collection,
-    test_util::{Basic, BasicByParentId, BasicCollection, TestDirectory},
+    test_util::{Basic, BasicByParentId, TestDirectory},
     Error,
 };
 use std::borrow::Cow;
@@ -14,13 +14,13 @@ use crate::Storage;
 #[tokio::test(flavor = "multi_thread")]
 async fn store_retrieve_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("store-retrieve-update");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
         parent_id: None,
     };
-    let collection = db.collection::<BasicCollection>()?;
+    let collection = db.collection::<Basic>()?;
     let header = collection.push(&original_value).await?;
 
     let mut doc = collection
@@ -52,10 +52,7 @@ async fn store_retrieve_update() -> Result<(), anyhow::Error> {
     assert!(transactions[0].id < transactions[1].id);
     for transaction in transactions {
         assert_eq!(transaction.changed_documents.len(), 1);
-        assert_eq!(
-            transaction.changed_documents[0].collection,
-            BasicCollection::id()
-        );
+        assert_eq!(transaction.changed_documents[0].collection, Basic::id());
         assert_eq!(transaction.changed_documents[0].id, header.id);
     }
 
@@ -65,9 +62,9 @@ async fn store_retrieve_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn not_found() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("not-found");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path).await?;
 
-    assert!(db.collection::<BasicCollection>()?.get(1).await?.is_none());
+    assert!(db.collection::<Basic>()?.get(1).await?.is_none());
 
     Ok(())
 }
@@ -75,13 +72,13 @@ async fn not_found() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn conflict() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("conflict");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
         parent_id: None,
     };
-    let collection = db.collection::<BasicCollection>()?;
+    let collection = db.collection::<Basic>()?;
     let header = collection.push(&original_value).await?;
 
     let mut doc = collection
@@ -102,7 +99,7 @@ async fn conflict() -> Result<(), anyhow::Error> {
         .expect_err("conflict should have generated an error")
     {
         Error::DocumentConflict(collection, id) => {
-            assert_eq!(collection, BasicCollection::id());
+            assert_eq!(collection, Basic::id());
             assert_eq!(id, doc.header.id);
         }
         other => return Err(anyhow::Error::from(other)),
@@ -114,12 +111,12 @@ async fn conflict() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn bad_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("bad_update");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path).await?;
 
-    let mut doc = Document::with_contents(1, &Basic::default(), BasicCollection::id())?;
+    let mut doc = Document::with_contents(1, &Basic::default(), Basic::id())?;
     match db.update(&mut doc).await {
         Err(Error::DocumentNotFound(collection, id)) => {
-            assert_eq!(collection, BasicCollection::id());
+            assert_eq!(collection, Basic::id());
             assert_eq!(id, 1);
             Ok(())
         }
@@ -130,13 +127,13 @@ async fn bad_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("no-update");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
         parent_id: None,
     };
-    let collection = db.collection::<BasicCollection>()?;
+    let collection = db.collection::<Basic>()?;
     let header = collection.push(&original_value).await?;
 
     let mut doc = collection
@@ -153,8 +150,8 @@ async fn no_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_transactions() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("list-transactions");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
-    let collection = db.collection::<BasicCollection>()?;
+    let db = Storage::<Basic>::open_local(path).await?;
+    let collection = db.collection::<Basic>()?;
 
     // create LIST_TRANSACTIONS_MAX_RESULTS + 1 items, giving us just enough
     // transactions to test the edge cases of `list_transactions`
@@ -202,8 +199,8 @@ async fn list_transactions() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn view_query() -> anyhow::Result<()> {
     let path = TestDirectory::new("list-transactions");
-    let db = Storage::<BasicCollection>::open_local(path).await?;
-    let collection = db.collection::<BasicCollection>()?;
+    let db = Storage::<Basic>::open_local(path).await?;
+    let collection = db.collection::<Basic>()?;
     let a = collection
         .push(&Basic {
             value: String::from("A"),

--- a/local/src/tests.rs
+++ b/local/src/tests.rs
@@ -14,7 +14,7 @@ use crate::Storage;
 #[tokio::test(flavor = "multi_thread")]
 async fn store_retrieve_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("store-retrieve-update");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
@@ -62,7 +62,7 @@ async fn store_retrieve_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn not_found() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("not-found");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
 
     assert!(db.collection::<Basic>()?.get(1).await?.is_none());
 
@@ -72,7 +72,7 @@ async fn not_found() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn conflict() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("conflict");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
@@ -111,7 +111,7 @@ async fn conflict() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn bad_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("bad_update");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
 
     let mut doc = Document::with_contents(1, &Basic::default(), Basic::id())?;
     match db.update(&mut doc).await {
@@ -127,7 +127,7 @@ async fn bad_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_update() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("no-update");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
 
     let original_value = Basic {
         value: String::from("initial_value"),
@@ -150,7 +150,7 @@ async fn no_update() -> Result<(), anyhow::Error> {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_transactions() -> Result<(), anyhow::Error> {
     let path = TestDirectory::new("list-transactions");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
     let collection = db.collection::<Basic>()?;
 
     // create LIST_TRANSACTIONS_MAX_RESULTS + 1 items, giving us just enough
@@ -198,8 +198,8 @@ async fn list_transactions() -> Result<(), anyhow::Error> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn view_query() -> anyhow::Result<()> {
-    let path = TestDirectory::new("list-transactions");
-    let db = Storage::<Basic>::open_local(path).await?;
+    let path = TestDirectory::new("view-query");
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
     let collection = db.collection::<Basic>()?;
     let a = collection
         .push(&Basic {

--- a/local/src/tests.rs
+++ b/local/src/tests.rs
@@ -4,7 +4,7 @@ use pliantdb_core::{
     connection::Connection,
     document::Document,
     schema::Collection,
-    test_util::{Basic, BasicByCategory, BasicByParentId, TestDirectory},
+    test_util::{Basic, BasicByCategory, BasicByParentId, TestDirectory, UnassociatedCollection},
     Error,
 };
 use storage::{LIST_TRANSACTIONS_DEFAULT_RESULT_COUNT, LIST_TRANSACTIONS_MAX_RESULTS};
@@ -245,6 +245,18 @@ async fn view_query() -> anyhow::Result<()> {
 
     let items_with_categories = db.view::<BasicByCategory>().query().await?;
     assert_eq!(items_with_categories.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unassociated_collection() -> Result<(), anyhow::Error> {
+    let path = TestDirectory::new("unassociated-collection");
+    let db = Storage::<Basic>::open_local(path, &Configuration::default()).await?;
+    assert!(matches!(
+        db.collection::<UnassociatedCollection>(),
+        Err(pliantdb_core::Error::CollectionNotFound)
+    ));
 
     Ok(())
 }

--- a/local/src/tests.rs
+++ b/local/src/tests.rs
@@ -200,7 +200,6 @@ async fn list_transactions() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "API not finished"]
 async fn view_query() -> anyhow::Result<()> {
     let path = TestDirectory::new("list-transactions");
     let db = Storage::<BasicCollection>::open_local(path).await?;

--- a/local/src/views.rs
+++ b/local/src/views.rs
@@ -1,7 +1,7 @@
 use pliantdb_core::schema::collection;
+use serde::{Deserialize, Serialize};
 
 use self::{integrity_scanner::IntegrityScan, mapper::Map};
-use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
 pub struct ViewEntry {

--- a/local/src/views.rs
+++ b/local/src/views.rs
@@ -1,0 +1,33 @@
+use std::borrow::Cow;
+
+use pliantdb_core::schema::{collection, map};
+
+use self::integrity_scanner::IntegrityScan;
+pub struct MapEntry<'a> {
+    pub view_version: usize,
+    pub maps: Vec<map::Serialized<'a>>,
+}
+
+pub mod integrity_scanner;
+
+pub fn view_entries_tree_name(collection: &collection::Id, view_name: &str) -> String {
+    format!("{}::{}", collection.0, view_name)
+}
+
+/// Used to store Document ID -> Key mappings, so that when a document is updated, we can remove the old entry.
+pub fn view_document_map_tree_name(collection: &collection::Id, view_name: &str) -> String {
+    format!("{}::{}::document-map", collection.0, view_name)
+}
+
+pub fn view_invalidated_docs_tree_name(collection: &collection::Id, view_name: &str) -> String {
+    format!("{}::{}::invalidated", collection.0, view_name)
+}
+
+pub fn view_omitted_docs_tree_name(collection: &collection::Id, view_name: &str) -> String {
+    format!("{}::{}::omitted", collection.0, view_name)
+}
+
+pub enum Task<'a> {
+    IntegrityScan(Cow<'a, IntegrityScan>),
+    // ViewMap(Cow<'a, IntegrityScan>),
+}

--- a/local/src/views.rs
+++ b/local/src/views.rs
@@ -1,6 +1,4 @@
-use std::borrow::Cow;
-
-use pliantdb_core::schema::{collection, map};
+use pliantdb_core::schema::collection;
 
 use self::{integrity_scanner::IntegrityScan, mapper::Map};
 use serde::{Deserialize, Serialize};
@@ -14,7 +12,7 @@ pub struct ViewEntry {
 #[derive(Serialize, Deserialize)]
 pub struct EntryMapping {
     pub source: u64,
-    pub value: serde_cbor::Value,
+    pub value: Vec<u8>,
 }
 
 pub mod integrity_scanner;
@@ -37,7 +35,8 @@ pub fn view_omitted_docs_tree_name(collection: &collection::Id, view_name: &str)
     format!("{}::{}::omitted", collection.0, view_name)
 }
 
-pub enum Task<'a> {
-    IntegrityScan(Cow<'a, IntegrityScan>),
-    ViewMap(Cow<'a, Map>),
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum Task {
+    IntegrityScan(IntegrityScan),
+    ViewMap(Map),
 }

--- a/local/src/views.rs
+++ b/local/src/views.rs
@@ -2,13 +2,23 @@ use std::borrow::Cow;
 
 use pliantdb_core::schema::{collection, map};
 
-use self::integrity_scanner::IntegrityScan;
-pub struct MapEntry<'a> {
+use self::{integrity_scanner::IntegrityScan, mapper::Map};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ViewEntry {
     pub view_version: usize,
-    pub maps: Vec<map::Serialized<'a>>,
+    pub mappings: Vec<EntryMapping>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct EntryMapping {
+    pub source: u64,
+    pub value: serde_cbor::Value,
 }
 
 pub mod integrity_scanner;
+pub mod mapper;
 
 pub fn view_entries_tree_name(collection: &collection::Id, view_name: &str) -> String {
     format!("{}::{}", collection.0, view_name)
@@ -29,5 +39,5 @@ pub fn view_omitted_docs_tree_name(collection: &collection::Id, view_name: &str)
 
 pub enum Task<'a> {
     IntegrityScan(Cow<'a, IntegrityScan>),
-    // ViewMap(Cow<'a, IntegrityScan>),
+    ViewMap(Cow<'a, Map>),
 }

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -5,9 +5,9 @@ use pliantdb_core::schema::{collection, Database, Key};
 use pliantdb_jobs::{Job, Keyed};
 use sled::{IVec, Tree};
 
-use crate::Storage;
+use crate::{storage::document_tree_name, Storage};
 
-use super::{view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name};
+use super::{view_document_map_tree_name, view_invalidated_docs_tree_name};
 
 #[derive(Debug)]
 pub struct IntegrityScanner<DB> {
@@ -30,10 +30,10 @@ where
     type Output = ();
 
     async fn execute(&mut self) -> anyhow::Result<Self::Output> {
-        let documents = self.storage.sled.open_tree(view_entries_tree_name(
-            &self.scan.collection,
-            &self.scan.view_name,
-        ))?;
+        let documents = self
+            .storage
+            .sled
+            .open_tree(document_tree_name(&self.scan.collection))?;
 
         let document_map = self.storage.sled.open_tree(view_document_map_tree_name(
             &self.scan.collection,

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -1,0 +1,128 @@
+use std::{borrow::Cow, collections::HashSet, hash::Hash};
+
+use async_trait::async_trait;
+use pliantdb_core::schema::{collection, Database, Key};
+use pliantdb_jobs::{Job, Keyed};
+use sled::{IVec, Tree};
+
+use crate::Storage;
+
+use super::{view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name};
+
+#[derive(Debug)]
+pub struct IntegrityScanner<DB> {
+    storage: Storage<DB>,
+    scan: IntegrityScan,
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub struct IntegrityScan {
+    pub view_version: usize,
+    pub collection: collection::Id,
+    pub view_name: Cow<'static, str>,
+}
+
+#[async_trait]
+impl<DB> Job for IntegrityScanner<DB>
+where
+    DB: Database,
+{
+    type Output = ();
+
+    async fn execute(&mut self) -> anyhow::Result<Self::Output> {
+        let documents = self.storage.sled.open_tree(view_entries_tree_name(
+            &self.scan.collection,
+            &self.scan.view_name,
+        ))?;
+
+        let document_map = self.storage.sled.open_tree(view_document_map_tree_name(
+            &self.scan.collection,
+            &self.scan.view_name,
+        ))?;
+
+        let invalidated_entries = self
+            .storage
+            .sled
+            .open_tree(view_invalidated_docs_tree_name(
+                &self.scan.collection,
+                &self.scan.view_name,
+            ))?;
+
+        let needs_update = tokio::task::spawn_blocking::<_, anyhow::Result<bool>>(move || {
+            let document_ids = tree_keys::<u64>(&documents)?;
+            let stored_document_ids = tree_keys::<u64>(&document_map)?;
+
+            let missing_entries = document_ids
+                .difference(&stored_document_ids)
+                .cloned()
+                .collect::<HashSet<_>>();
+
+            if !missing_entries.is_empty() {
+                // Add all missing entries to the invalidated list. The view
+                // mapping job will update them on the next pass.
+                invalidated_entries
+                    .transaction::<_, _, anyhow::Error>(|tree| {
+                        for id in &missing_entries {
+                            tree.insert(id.as_big_endian_bytes().as_ref(), IVec::default())?;
+                        }
+                        Ok(())
+                    })
+                    .map_err(|err| match err {
+                        sled::transaction::TransactionError::Abort(err) => err,
+                        sled::transaction::TransactionError::Storage(err) => {
+                            anyhow::Error::from(err)
+                        }
+                    })?;
+
+                return Ok(true);
+            }
+
+            Ok(false)
+        })
+        .await??;
+
+        if needs_update {
+            todo!("Spawn a view map job")
+        }
+
+        Ok(())
+    }
+}
+
+fn tree_keys<K: Key + Hash + Eq + Clone>(tree: &Tree) -> Result<HashSet<K>, sled::Error> {
+    let mut ids = HashSet::new();
+    for result in tree.iter() {
+        let (key, _) = result?;
+        let key = K::from_big_endian_bytes(&key);
+        ids.insert(key);
+    }
+
+    Ok(ids)
+}
+
+impl<DB> Keyed<IntegrityScan> for IntegrityScanner<DB>
+where
+    DB: Database,
+{
+    fn key(&self) -> Cow<'_, IntegrityScan> {
+        Cow::Borrowed(&self.scan)
+    }
+}
+
+// The reason we use jobs like this is to make sure we can tweak how much is
+// happening at any given time.
+//
+// On the Server level, we'll need to cooperate with all the databases in a
+// shared pool of workers. So, we need to come up with a design for the view
+// updaters to work within this limitation.
+//
+// Integrity scan is simple: Have a shared structure on Storage that keeps track
+// of all integrity scan results. It can check for an existing value and return,
+// or make you wait until the job is finished. For views, I suppose the best
+// that can be done is a similar approach, but the indexer's output is the last
+// transaction id it synced. When a request comes in, a check can be done if
+// there are any docs outdated, if so, the client can get the current transaction id
+// and ask the ViewScanning service manager to wait until that txid is scanned.
+//
+// The view can then scan and return the results it finds with confidence it was updated to that time.
+// If new requests come in while the current batch is being caught up to,

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -5,12 +5,11 @@ use pliantdb_core::schema::{collection, Database, Key};
 use pliantdb_jobs::{Job, Keyed};
 use sled::{IVec, Tree};
 
-use crate::{storage::document_tree_name, Storage};
-
 use super::{
     mapper::{Map, Mapper},
     view_document_map_tree_name, view_invalidated_docs_tree_name, Task,
 };
+use crate::{storage::document_tree_name, Storage};
 
 #[derive(Debug)]
 pub struct IntegrityScanner<DB> {

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -104,6 +104,14 @@ where
             job.receive().await.unwrap();
         }
 
+        self.storage
+            .tasks
+            .mark_integrity_check_complete(
+                self.scan.collection.clone(),
+                self.scan.view_name.clone(),
+            )
+            .await;
+
         Ok(())
     }
 }

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -87,7 +87,6 @@ where
         .await??;
 
         if needs_update {
-            println!("needs update after integrity scan");
             let job = self
                 .storage
                 .tasks
@@ -100,8 +99,7 @@ where
                     },
                 })
                 .await;
-            let updated_to_transaction = job.receive().await.unwrap();
-            println!("Updated to transaction: {:?}", updated_to_transaction);
+            job.receive().await.unwrap();
         }
 
         Ok(())

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -75,7 +75,7 @@ where
         let map_request = self.map.clone();
 
         tokio::task::spawn_blocking(move || {
-            dbg!(map_view(
+            map_view(
                 &invalidated_entries,
                 &document_map,
                 &documents,
@@ -83,7 +83,7 @@ where
                 &view_entries,
                 &storage,
                 &map_request,
-            ))
+            )
         })
         .await??;
 

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -1,0 +1,198 @@
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use pliantdb_core::{
+    document::Document,
+    schema::{collection, map, Database},
+};
+use pliantdb_jobs::Job;
+
+use crate::{storage::document_tree_name, Storage};
+
+use super::{
+    view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
+    view_omitted_docs_tree_name, EntryMapping, ViewEntry,
+};
+use sled::{transaction::ConflictableTransactionError, IVec, Transactional};
+
+#[derive(Debug)]
+pub struct Mapper<DB> {
+    storage: Storage<DB>,
+    map: Map,
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+pub struct Map {
+    collection: collection::Id,
+    view_name: Cow<'static, str>,
+}
+
+#[async_trait]
+impl<DB> Job for Mapper<DB>
+where
+    DB: Database,
+{
+    type Output = u64;
+
+    #[allow(clippy::clippy::too_many_lines)] // I'm well aware clippy, thank you for turning my entire screen yellow
+    async fn execute(&mut self) -> anyhow::Result<Self::Output> {
+        let documents = self
+            .storage
+            .sled
+            .open_tree(document_tree_name(&self.map.collection))?;
+
+        let view_entries = self.storage.sled.open_tree(view_entries_tree_name(
+            &self.map.collection,
+            &self.map.view_name,
+        ))?;
+
+        let document_map = self.storage.sled.open_tree(view_document_map_tree_name(
+            &self.map.collection,
+            &self.map.view_name,
+        ))?;
+
+        let invalidated_entries = self
+            .storage
+            .sled
+            .open_tree(view_invalidated_docs_tree_name(
+                &self.map.collection,
+                &self.map.view_name,
+            ))?;
+
+        let omitted_entries = self.storage.sled.open_tree(view_omitted_docs_tree_name(
+            &self.map.collection,
+            &self.map.view_name,
+        ))?;
+        let transaction_id = self
+            .storage
+            .last_transaction_id()
+            .await?
+            .expect("no way to have documents without a transaction");
+
+        let storage = self.storage.clone();
+        let map_request = self.map.clone();
+
+        tokio::task::spawn_blocking::<_, anyhow::Result<u64>>(move || {
+            // TODO refactor into its own method
+            // Only do any work if there are invalidated documents to process
+            let invalidated_ids = invalidated_entries
+                .iter()
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .map(|(key, _)| key)
+                .collect::<Vec<_>>();
+            if !invalidated_ids.is_empty() {
+                (
+                    &invalidated_entries,
+                    &document_map,
+                    &documents,
+                    &omitted_entries,
+                )
+                    .transaction(
+                        |(invalidated_entries, document_map, documents, omitted_entries)| {
+                            for document_id in &invalidated_ids {
+                                // TODO refactor into its own method
+                                invalidated_entries.remove(document_id)?;
+
+                                let document = documents.get(document_id)?.unwrap();
+                                let document = bincode::deserialize::<Document<'_>>(&document)
+                                    .map_err(|err| {
+                                        ConflictableTransactionError::Abort(anyhow::Error::from(
+                                            err,
+                                        ))
+                                    })?;
+
+                                // Call the schema map function
+                                let view =
+                                    storage.schema.view_by_name(&map_request.view_name).unwrap();
+                                let map_result = view.map(&document).map_err(|err| {
+                                    ConflictableTransactionError::Abort(anyhow::Error::from(err))
+                                })?;
+
+                                if let Some(map::Serialized { source, key, value }) = map_result {
+                                    omitted_entries.remove(document_id)?;
+
+                                    // When map results are returned, the document
+                                    // map will contain an array of keys that the
+                                    // document returned. Currently we only support
+                                    // single emits, so it's going to be a
+                                    // single-entry vec for now.
+                                    let keys = vec![Cow::Borrowed(&key)];
+                                    document_map.insert(
+                                        document_id,
+                                        bincode::serialize(&keys).map_err(|err| {
+                                            ConflictableTransactionError::Abort(
+                                                anyhow::Error::from(err),
+                                            )
+                                        })?,
+                                    )?;
+
+                                    let entry_mapping = EntryMapping { source, value };
+
+                                    // Add a new ViewEntry or update an existing
+                                    // ViewEntry for the key given
+                                    let view_entry =
+                                        if let Some(existing_entry) = view_entries.get(&key)? {
+                                            let mut entry =
+                                                bincode::deserialize::<ViewEntry>(&existing_entry)
+                                                    .map_err(|err| {
+                                                        ConflictableTransactionError::Abort(
+                                                            anyhow::Error::from(err),
+                                                        )
+                                                    })?;
+
+                                            // attempt to update an existing
+                                            // entry for this document, if
+                                            // present
+                                            let mut found = false;
+                                            for mapping in &mut entry.mappings {
+                                                if mapping.source == source {
+                                                    found = true;
+                                                    mapping.value = entry_mapping.value.clone();
+                                                    break;
+                                                }
+                                            }
+
+                                            // If an existing mapping wasn't
+                                            // found, add it
+                                            if !found {
+                                                entry.mappings.push(entry_mapping);
+                                            }
+
+                                            entry
+                                        } else {
+                                            ViewEntry {
+                                                view_version: view.version(),
+                                                mappings: vec![entry_mapping],
+                                            }
+                                        };
+                                    view_entries.insert(
+                                        key,
+                                        bincode::serialize(&view_entry).map_err(|err| {
+                                            ConflictableTransactionError::Abort(
+                                                anyhow::Error::from(err),
+                                            )
+                                        })?,
+                                    )?;
+                                } else {
+                                    // When no entry is emitted, the document map is emptied and a note is made in omitted_entries
+                                    document_map.remove(document_id)?;
+                                    omitted_entries.insert(document_id, IVec::default())?;
+                                }
+                            }
+                            Ok(())
+                        },
+                    )
+                    .map_err(|err| match err {
+                        sled::transaction::TransactionError::Abort(err) => err,
+                        sled::transaction::TransactionError::Storage(err) => {
+                            anyhow::Error::from(err)
+                        }
+                    })?;
+            }
+
+            Ok(transaction_id)
+        })
+        .await?
+    }
+}

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -5,26 +5,29 @@ use pliantdb_core::{
     document::Document,
     schema::{collection, map, Database},
 };
-use pliantdb_jobs::Job;
+use pliantdb_jobs::{Job, Keyed};
 
 use crate::{storage::document_tree_name, Storage};
 
 use super::{
     view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
-    view_omitted_docs_tree_name, EntryMapping, ViewEntry,
+    view_omitted_docs_tree_name, EntryMapping, Task, ViewEntry,
 };
-use sled::{transaction::ConflictableTransactionError, IVec, Transactional};
+use sled::{
+    transaction::{ConflictableTransactionError, TransactionalTree},
+    IVec, Transactional, Tree,
+};
 
 #[derive(Debug)]
 pub struct Mapper<DB> {
-    storage: Storage<DB>,
-    map: Map,
+    pub storage: Storage<DB>,
+    pub map: Map,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub struct Map {
-    collection: collection::Id,
-    view_name: Cow<'static, str>,
+    pub collection: collection::Id,
+    pub view_name: Cow<'static, str>,
 }
 
 #[async_trait]
@@ -34,7 +37,7 @@ where
 {
     type Output = u64;
 
-    #[allow(clippy::clippy::too_many_lines)] // I'm well aware clippy, thank you for turning my entire screen yellow
+    #[allow(clippy::clippy::too_many_lines)]
     async fn execute(&mut self) -> anyhow::Result<Self::Output> {
         let documents = self
             .storage
@@ -72,127 +75,178 @@ where
         let storage = self.storage.clone();
         let map_request = self.map.clone();
 
-        tokio::task::spawn_blocking::<_, anyhow::Result<u64>>(move || {
-            // TODO refactor into its own method
-            // Only do any work if there are invalidated documents to process
-            let invalidated_ids = invalidated_entries
-                .iter()
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .map(|(key, _)| key)
-                .collect::<Vec<_>>();
-            if !invalidated_ids.is_empty() {
-                (
-                    &invalidated_entries,
-                    &document_map,
-                    &documents,
-                    &omitted_entries,
-                )
-                    .transaction(
-                        |(invalidated_entries, document_map, documents, omitted_entries)| {
-                            for document_id in &invalidated_ids {
-                                // TODO refactor into its own method
-                                invalidated_entries.remove(document_id)?;
-
-                                let document = documents.get(document_id)?.unwrap();
-                                let document = bincode::deserialize::<Document<'_>>(&document)
-                                    .map_err(|err| {
-                                        ConflictableTransactionError::Abort(anyhow::Error::from(
-                                            err,
-                                        ))
-                                    })?;
-
-                                // Call the schema map function
-                                let view =
-                                    storage.schema.view_by_name(&map_request.view_name).unwrap();
-                                let map_result = view.map(&document).map_err(|err| {
-                                    ConflictableTransactionError::Abort(anyhow::Error::from(err))
-                                })?;
-
-                                if let Some(map::Serialized { source, key, value }) = map_result {
-                                    omitted_entries.remove(document_id)?;
-
-                                    // When map results are returned, the document
-                                    // map will contain an array of keys that the
-                                    // document returned. Currently we only support
-                                    // single emits, so it's going to be a
-                                    // single-entry vec for now.
-                                    let keys = vec![Cow::Borrowed(&key)];
-                                    document_map.insert(
-                                        document_id,
-                                        bincode::serialize(&keys).map_err(|err| {
-                                            ConflictableTransactionError::Abort(
-                                                anyhow::Error::from(err),
-                                            )
-                                        })?,
-                                    )?;
-
-                                    let entry_mapping = EntryMapping { source, value };
-
-                                    // Add a new ViewEntry or update an existing
-                                    // ViewEntry for the key given
-                                    let view_entry =
-                                        if let Some(existing_entry) = view_entries.get(&key)? {
-                                            let mut entry =
-                                                bincode::deserialize::<ViewEntry>(&existing_entry)
-                                                    .map_err(|err| {
-                                                        ConflictableTransactionError::Abort(
-                                                            anyhow::Error::from(err),
-                                                        )
-                                                    })?;
-
-                                            // attempt to update an existing
-                                            // entry for this document, if
-                                            // present
-                                            let mut found = false;
-                                            for mapping in &mut entry.mappings {
-                                                if mapping.source == source {
-                                                    found = true;
-                                                    mapping.value = entry_mapping.value.clone();
-                                                    break;
-                                                }
-                                            }
-
-                                            // If an existing mapping wasn't
-                                            // found, add it
-                                            if !found {
-                                                entry.mappings.push(entry_mapping);
-                                            }
-
-                                            entry
-                                        } else {
-                                            ViewEntry {
-                                                view_version: view.version(),
-                                                mappings: vec![entry_mapping],
-                                            }
-                                        };
-                                    view_entries.insert(
-                                        key,
-                                        bincode::serialize(&view_entry).map_err(|err| {
-                                            ConflictableTransactionError::Abort(
-                                                anyhow::Error::from(err),
-                                            )
-                                        })?,
-                                    )?;
-                                } else {
-                                    // When no entry is emitted, the document map is emptied and a note is made in omitted_entries
-                                    document_map.remove(document_id)?;
-                                    omitted_entries.insert(document_id, IVec::default())?;
-                                }
-                            }
-                            Ok(())
-                        },
-                    )
-                    .map_err(|err| match err {
-                        sled::transaction::TransactionError::Abort(err) => err,
-                        sled::transaction::TransactionError::Storage(err) => {
-                            anyhow::Error::from(err)
-                        }
-                    })?;
-            }
-
-            Ok(transaction_id)
+        tokio::task::spawn_blocking(move || {
+            dbg!(map_view(
+                &invalidated_entries,
+                &document_map,
+                &documents,
+                &omitted_entries,
+                &view_entries,
+                &storage,
+                &map_request,
+            ))
         })
-        .await?
+        .await??;
+
+        println!("Returning");
+        Ok(transaction_id)
+    }
+}
+
+fn map_view<DB: Database>(
+    invalidated_entries: &Tree,
+    document_map: &Tree,
+    documents: &Tree,
+    omitted_entries: &Tree,
+    view_entries: &Tree,
+    storage: &Storage<DB>,
+    map_request: &Map,
+) -> anyhow::Result<()> {
+    // Only do any work if there are invalidated documents to process
+    let invalidated_ids = invalidated_entries
+        .iter()
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|(key, _)| key)
+        .collect::<Vec<_>>();
+    if !invalidated_ids.is_empty() {
+        (
+            invalidated_entries,
+            document_map,
+            documents,
+            omitted_entries,
+            view_entries,
+        )
+            .transaction(
+                |(invalidated_entries, document_map, documents, omitted_entries, view_entries)| {
+                    for document_id in &invalidated_ids {
+                        DocumentRequest {
+                            document_id,
+                            map_request,
+                            invalidated_entries,
+                            document_map,
+                            documents,
+                            omitted_entries,
+                            view_entries,
+                            storage,
+                        }
+                        .map()?;
+                    }
+                    Ok(())
+                },
+            )
+            .map_err(|err| match err {
+                sled::transaction::TransactionError::Abort(err) => err,
+                sled::transaction::TransactionError::Storage(err) => anyhow::Error::from(err),
+            })?;
+    }
+
+    Ok(())
+}
+
+struct DocumentRequest<'a, DB> {
+    document_id: &'a IVec,
+    map_request: &'a Map,
+
+    invalidated_entries: &'a TransactionalTree,
+    document_map: &'a TransactionalTree,
+    documents: &'a TransactionalTree,
+    omitted_entries: &'a TransactionalTree,
+    view_entries: &'a TransactionalTree,
+    storage: &'a Storage<DB>,
+}
+
+impl<'a, DB: Database> DocumentRequest<'a, DB> {
+    fn map(&self) -> Result<(), ConflictableTransactionError<anyhow::Error>> {
+        self.invalidated_entries.remove(self.document_id)?;
+
+        let document = self.documents.get(self.document_id)?.unwrap();
+        let document = bincode::deserialize::<Document<'_>>(&document)
+            .map_err(|err| ConflictableTransactionError::Abort(anyhow::Error::from(err)))?;
+
+        // Call the schema map function
+        let view = self
+            .storage
+            .schema
+            .view_by_name(&self.map_request.view_name)
+            .unwrap();
+        let map_result = view
+            .map(&document)
+            .map_err(|err| ConflictableTransactionError::Abort(anyhow::Error::from(err)))?;
+
+        if let Some(map::Serialized { source, key, value }) = map_result {
+            self.omitted_entries.remove(self.document_id)?;
+
+            // When map results are returned, the document
+            // map will contain an array of keys that the
+            // document returned. Currently we only support
+            // single emits, so it's going to be a
+            // single-entry vec for now.
+            let keys = vec![Cow::Borrowed(&key)];
+            assert!(self
+                .document_map
+                .insert(
+                    self.document_id,
+                    bincode::serialize(&keys).map_err(|err| {
+                        ConflictableTransactionError::Abort(anyhow::Error::from(err))
+                    })?,
+                )?
+                .is_none()); // TODO need to implement updating an existing document's entries -- have to remove the entries for the old key it used to have
+
+            let entry_mapping = EntryMapping { source, value };
+
+            // Add a new ViewEntry or update an existing
+            // ViewEntry for the key given
+            let view_entry = if let Some(existing_entry) = self.view_entries.get(&key)? {
+                let mut entry = bincode::deserialize::<ViewEntry>(&existing_entry)
+                    .map_err(|err| ConflictableTransactionError::Abort(anyhow::Error::from(err)))?;
+
+                // attempt to update an existing
+                // entry for this document, if
+                // present
+                let mut found = false;
+                for mapping in &mut entry.mappings {
+                    if mapping.source == source {
+                        found = true;
+                        mapping.value = entry_mapping.value.clone();
+                        break;
+                    }
+                }
+
+                // If an existing mapping wasn't
+                // found, add it
+                if !found {
+                    entry.mappings.push(entry_mapping);
+                }
+
+                entry
+            } else {
+                ViewEntry {
+                    view_version: view.version(),
+                    mappings: vec![entry_mapping],
+                }
+            };
+            self.view_entries.insert(
+                key,
+                bincode::serialize(&view_entry)
+                    .map_err(|err| ConflictableTransactionError::Abort(anyhow::Error::from(err)))?,
+            )?;
+        } else {
+            // When no entry is emitted, the document map is emptied and a note is made in omitted_entries
+            self.document_map.remove(self.document_id)?;
+            self.omitted_entries
+                .insert(self.document_id, IVec::default())?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<DB> Keyed<Task> for Mapper<DB>
+where
+    DB: Database,
+{
+    fn key(&self) -> Task {
+        Task::ViewMap(self.map.clone())
     }
 }

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -88,7 +88,6 @@ where
         })
         .await??;
 
-        println!("Returning");
         Ok(transaction_id)
     }
 }

--- a/pliantdb/examples/basic-local.rs
+++ b/pliantdb/examples/basic-local.rs
@@ -7,7 +7,7 @@ use pliantdb_core::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct Message {
     pub timestamp: SystemTime,
     pub contents: String,
@@ -23,7 +23,7 @@ impl Collection for Message {
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let db = Storage::<Message>::open_local("basic.pliantdb")?;
+    let db = Storage::<Message>::open_local("basic.pliantdb").await?;
     let messages = db.collection::<Message>()?;
 
     // Insert a new `Message` into the collection. The `push()` method used

--- a/pliantdb/examples/basic-local.rs
+++ b/pliantdb/examples/basic-local.rs
@@ -5,6 +5,7 @@ use pliantdb_core::{
     connection::Connection,
     schema::{collection, Collection, Schema},
 };
+use pliantdb_local::Configuration;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -23,7 +24,7 @@ impl Collection for Message {
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let db = Storage::<Message>::open_local("basic.pliantdb").await?;
+    let db = Storage::<Message>::open_local("basic.pliantdb", &Configuration::default()).await?;
     let messages = db.collection::<Message>()?;
 
     // Insert a new `Message` into the collection. The `push()` method used


### PR DESCRIPTION
* [x] Add the start of the job queueing system. The goal is to have a layer that is unit tested that gets shared between the local storage and server implementations. There will likely be configuration options that both layers use, but the jobs themselves will be different. Closes #4.
* [x] Implement view caching job. 
* [x] Implement view query API. Closes #3.
* [ ] ~Test enabling integrity check on launch~
* [x] Fix integrity check to actually save the values so it doesn't run twice
  * [ ] ~Test it~
* [x] Test last_transaction_id on an empty database
* [x] Test Connection::collection when the collection isn't in the schema
* [x] Test Range-based queries
* [x] Test Multiple-get queries