### PR TITLE
Refactored Ids to namespaced names.

### DIFF
--- a/.baked-md/README.md
+++ b/.baked-md/README.md
@@ -1,0 +1,5 @@
+# About this folder
+
+This folder contains markdown files for use with [md-bakery](https://github.com/PsichiX/md-bakery).
+
+To re-make generated markdown files, run [`./bake-markdown.sh`](../bake-markdown.sh) in the repository's root folder.

--- a/.baked-md/project-readme.md
+++ b/.baked-md/project-readme.md
@@ -31,74 +31,20 @@ If you're interested in chatting about this project or potentially wanting to co
 
 Check out [./pliantdb/examples](./pliantdb/examples) for examples. To get an idea of how it works, this is a simple schema:
 
-```rust
-#[derive(Debug, Serialize, Deserialize)]
-struct Shape {
-    pub sides: u32,
-}
-
-impl Collection for Shape {
-    fn collection_name() -> Result<CollectionName, InvalidNameError> {
-        CollectionName::new("khonsulabs", "shapes")
-    }
-
-    fn define_views(schema: &mut Schematic) -> Result<(), Error> {
-        schema.define_view(ShapesByNumberOfSides)
-    }
-}
-
-#[derive(Debug)]
-struct ShapesByNumberOfSides;
-
-impl View for ShapesByNumberOfSides {
-    type Collection = Shape;
-
-    type Key = u32;
-
-    type Value = usize;
-
-    fn version(&self) -> u64 {
-        1
-    }
-
-    fn name(&self) -> Result<Name, InvalidNameError> {
-        Name::new("by-number-of-sides")
-    }
-
-    fn map(&self, document: &Document<'_>) -> MapResult<Self::Key, Self::Value> {
-        let shape = document.contents::<Shape>()?;
-        Ok(Some(document.emit_key_and_value(shape.sides, 1)))
-    }
-
-    fn reduce(
-        &self,
-        mappings: &[MappedValue<Self::Key, Self::Value>],
-        _rereduce: bool,
-    ) -> Result<Self::Value, view::Error> {
-        Ok(mappings.iter().map(|m| m.value).sum())
-    }
-}
+```rust: source @ snippet-a
+pliantdb/examples/view-examples.rs
 ```
 
 After you have your collection(s) defined, you can open up a database and insert documents:
 
-```rust
-    let db =
-        Storage::<Shape>::open_local("view-examples.pliantdb", &Configuration::default()).await?;
-
-    // Insert a new document into the Shape collection.
-    db.collection::<Shape>().push(&Shape::new(3)).await?;
+```rust: source @ snippet-b
+pliantdb/examples/view-examples.rs
 ```
 
 And query data using the Map-Reduce-powered view:
 
-```rust
-    let triangles = db
-        .view::<ShapesByNumberOfSides>()
-        .with_key(3)
-        .query()
-        .await?;
-    println!("Number of triangles: {}", triangles.len());
+```rust: source @ snippet-c
+pliantdb/examples/view-examples.rs
 ```
 
 ## Why write another database?

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ struct Shape {
 }
 
 impl Collection for Shape {
-    fn id() -> CollectionId {
-        CollectionId::from("shapes")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("khonsulabs", "shapes")
     }
 
-    fn define_views(schema: &mut Schema) {
-        schema.define_view(ShapesByNumberOfSides);
+    fn define_views(schema: &mut Schematic) -> Result<(), Error> {
+        schema.define_view(ShapesByNumberOfSides)
     }
 }
 
@@ -62,8 +62,8 @@ impl View for ShapesByNumberOfSides {
         1
     }
 
-    fn name(&self) -> Cow<'static, str> {
-        Cow::from("by-sides")
+    fn name(&self) -> Result<Name, InvalidNameError> {
+        Name::new("by-number-of-sides")
     }
 
     fn map(&self, document: &Document<'_>) -> MapResult<Self::Key> {

--- a/bake-markdown.sh
+++ b/bake-markdown.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mdbakery --input .baked-md/project-readme.md --output README.md

--- a/circulate/src/lib.rs
+++ b/circulate/src/lib.rs
@@ -291,6 +291,7 @@ impl Drop for SubscriberData {
     fn drop(&mut self) {
         let id = self.id;
         let relay = self.relay.clone();
+        // TODO Replace with a tokio runtime handle instead of global tokio::spawn
         tokio::spawn(async move {
             relay.unsubscribe_all(id).await;
         });

--- a/client/src/client/remote_database.rs
+++ b/client/src/client/remote_database.rs
@@ -58,7 +58,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
             .send_request(Request::Database {
                 database: self.name.to_string(),
                 request: DatabaseRequest::Get {
-                    collection: C::collection_id(),
+                    collection: C::collection_name()?,
                     id,
                 },
             })
@@ -84,7 +84,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
             .send_request(Request::Database {
                 database: self.name.to_string(),
                 request: DatabaseRequest::GetMultiple {
-                    collection: C::collection_id(),
+                    collection: C::collection_name()?,
                     ids: ids.to_vec(),
                 },
             })
@@ -115,7 +115,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
                         .schema
                         .view::<V>()
                         .ok_or(pliantdb_core::Error::CollectionNotFound)?
-                        .name(),
+                        .view_name()?,
                     key: key.map(|key| key.serialized()).transpose()?,
                     access_policy,
                     with_docs: false,
@@ -152,7 +152,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
                         .schema
                         .view::<V>()
                         .ok_or(pliantdb_core::Error::CollectionNotFound)?
-                        .name(),
+                        .view_name()?,
                     key: key.map(|key| key.serialized()).transpose()?,
                     access_policy,
                     with_docs: true,
@@ -189,7 +189,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
                         .schema
                         .view::<V>()
                         .ok_or(pliantdb_core::Error::CollectionNotFound)?
-                        .name(),
+                        .view_name()?,
                     key: key.map(|key| key.serialized()).transpose()?,
                     access_policy,
                     grouped: false,
@@ -225,7 +225,7 @@ impl<DB: Schema> Connection for RemoteDatabase<DB> {
                         .schema
                         .view::<V>()
                         .ok_or(pliantdb_core::Error::CollectionNotFound)?
-                        .name(),
+                        .view_name()?,
                     key: key.map(|key| key.serialized()).transpose()?,
                     access_policy,
                     grouped: true,

--- a/client/src/tests.rs
+++ b/client/src/tests.rs
@@ -73,9 +73,9 @@ mod websockets {
             let client = Client::new(&url, None).await?;
 
             client
-                .create_database(&test.to_string(), Basic::schema_id())
+                .create_database(&test.to_string(), Basic::schema_name()?)
                 .await?;
-            let db = client.database::<Basic>(&test.to_string()).await;
+            let db = client.database::<Basic>(&test.to_string()).await?;
 
             Ok(Self {
                 db,
@@ -118,9 +118,9 @@ mod pliant {
             let client = Client::new(&url, Some(server.certificate().await?)).await?;
 
             client
-                .create_database(&test.to_string(), Basic::schema_id())
+                .create_database(&test.to_string(), Basic::schema_name()?)
                 .await?;
-            let db = client.database::<Basic>(&test.to_string()).await;
+            let db = client.database::<Basic>(&test.to_string()).await?;
 
             Ok(Self {
                 db,

--- a/client/tests/simultaneous-connections.rs
+++ b/client/tests/simultaneous-connections.rs
@@ -40,10 +40,10 @@ async fn simultaneous_connections() -> anyhow::Result<()> {
 async fn test_one_client(client: Client, database_name: String) -> anyhow::Result<()> {
     for _ in 0u32..50 {
         client
-            .create_database(&database_name, Basic::schema_id())
+            .create_database(&database_name, Basic::schema_name()?)
             .await
             .unwrap();
-        let db = client.database::<Basic>(&database_name).await;
+        let db = client.database::<Basic>(&database_name).await?;
         test_util::store_retrieve_update_delete_tests(&db)
             .await
             .unwrap();

--- a/core/src/connection.rs
+++ b/core/src/connection.rs
@@ -25,7 +25,7 @@ pub trait Connection: Send + Sync {
     async fn insert<C: schema::Collection>(&self, contents: Vec<u8>) -> Result<Header, Error> {
         let mut tx = Transaction::default();
         tx.push(Operation {
-            collection: C::collection_id(),
+            collection: C::collection_name()?,
             command: Command::Insert {
                 contents: Cow::from(contents),
             },

--- a/core/src/document.rs
+++ b/core/src/document.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::schema::{CollectionId, Key, Map};
+use crate::schema::{CollectionName, Key, Map};
 
 mod revision;
 pub use revision::Revision;
@@ -21,7 +21,7 @@ pub struct Header {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Document<'a> {
     /// The `Id` of the `Collection` this document belongs to.
-    pub collection: CollectionId,
+    pub collection: CollectionName,
 
     /// The header of the document, which contains the id and `Revision`.
     pub header: Cow<'a, Header>,
@@ -33,7 +33,7 @@ pub struct Document<'a> {
 impl<'a> Document<'a> {
     /// Creates a new document with `contents`.
     #[must_use]
-    pub fn new(id: u64, contents: Cow<'a, [u8]>, collection: CollectionId) -> Self {
+    pub fn new(id: u64, contents: Cow<'a, [u8]>, collection: CollectionName) -> Self {
         let revision = Revision::new(&contents);
         Self {
             header: Cow::Owned(Header { id, revision }),
@@ -46,7 +46,7 @@ impl<'a> Document<'a> {
     pub fn with_contents<S: Serialize>(
         id: u64,
         contents: &S,
-        collection: CollectionId,
+        collection: CollectionName,
     ) -> Result<Self, serde_cbor::Error> {
         let contents = Cow::from(serde_cbor::to_vec(contents)?);
         Ok(Self::new(id, contents, collection))
@@ -129,7 +129,7 @@ fn emissions_tests() -> Result<(), crate::Error> {
         test_util::Basic,
     };
 
-    let doc = Document::with_contents(1, &Basic::default(), Basic::collection_id())?;
+    let doc = Document::with_contents(1, &Basic::default(), Basic::collection_name()?)?;
 
     assert_eq!(doc.emit(), Map::new(doc.header.id, (), ()));
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,7 +37,7 @@ pub mod transaction;
 /// Types for Publish/Subscribe (`PubSub`) messaging.
 pub mod pubsub;
 
-use schema::CollectionId;
+use schema::CollectionName;
 use serde::{Deserialize, Serialize};
 
 /// an enumeration of errors that this crate can produce
@@ -83,11 +83,15 @@ pub enum Error {
 
     /// An attempt to update a document that doesn't exist.
     #[error("the requested document id {1} from collection {0} was not found")]
-    DocumentNotFound(CollectionId, u64),
+    DocumentNotFound(CollectionName, u64),
 
     /// When updating a document, if a situation is detected where the contents have changed on the server since the `Revision` provided, a Conflict error will be returned.
     #[error("a conflict was detected while updating document id {1} from collection {0}")]
-    DocumentConflict(CollectionId, u64),
+    DocumentConflict(CollectionName, u64),
+
+    /// An invalid name was specified during schema creation.
+    #[error("an invalid name was used in a schema: {0}")]
+    InvalidName(#[from] schema::InvalidNameError),
 }
 
 impl From<serde_cbor::Error> for Error {

--- a/core/src/networking.rs
+++ b/core/src/networking.rs
@@ -1,9 +1,7 @@
-use std::borrow::Cow;
-
 use async_trait::async_trait;
 use circulate::Message;
 pub use fabruic;
-use schema::SchemaId;
+use schema::SchemaName;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
@@ -12,7 +10,7 @@ use crate::{
     schema::{
         self,
         view::{self, map},
-        CollectionId, Key, MappedValue,
+        CollectionName, Key, MappedValue, ViewName,
     },
     transaction::{Executed, OperationResult, Transaction},
 };
@@ -62,21 +60,21 @@ pub enum DatabaseRequest {
     /// Retrieve a single document.
     Get {
         /// The collection of the document.
-        collection: CollectionId,
+        collection: CollectionName,
         /// The id of the document.
         id: u64,
     },
     /// Retrieve multiple documents.
     GetMultiple {
         /// The collection of the documents.
-        collection: CollectionId,
+        collection: CollectionName,
         /// The ids of the documents.
         ids: Vec<u64>,
     },
     /// Queries a view.
     Query {
         /// The name of the view.
-        view: Cow<'static, str>,
+        view: ViewName,
         /// The filter for the view.
         key: Option<QueryKey<Vec<u8>>>,
         /// The access policy for the query.
@@ -89,7 +87,7 @@ pub enum DatabaseRequest {
     /// Reduces a view.
     Reduce {
         /// The name of the view.
-        view: Cow<'static, str>,
+        view: ViewName,
         /// The filter for the view.
         key: Option<QueryKey<Vec<u8>>>,
         /// The access policy for the query.
@@ -167,7 +165,7 @@ pub enum ServerResponse {
     /// A list of available databases.
     Databases(Vec<Database>),
     ///A list of availble schemas.
-    AvailableSchemas(Vec<SchemaId>),
+    AvailableSchemas(Vec<SchemaName>),
 }
 
 /// A response to a [`DatabaseRequest`].
@@ -238,13 +236,13 @@ pub struct Database {
     /// The name of the database.
     pub name: String,
     /// The schema defining the database.
-    pub schema: SchemaId,
+    pub schema: SchemaName,
 }
 
 /// Functions for interacting with a `PliantDB` server.
 #[async_trait]
 pub trait ServerConnection: Send + Sync {
-    /// Creates a database named `name` using the [`SchemaId`] `schema`.
+    /// Creates a database named `name` using the [`SchemaName`] `schema`.
     ///
     /// ## Errors
     ///
@@ -253,7 +251,7 @@ pub trait ServerConnection: Send + Sync {
     ///   alphanumeric, a period (`.`), or a hyphen (`-`).
     /// * [`Error::DatabaseNameAlreadyTaken]: `name` was already used for a
     ///   previous database name. Database names are case insensitive.
-    async fn create_database(&self, name: &str, schema: SchemaId) -> Result<(), crate::Error>;
+    async fn create_database(&self, name: &str, schema: SchemaName) -> Result<(), crate::Error>;
 
     /// Deletes a database named `name`.
     ///
@@ -266,8 +264,8 @@ pub trait ServerConnection: Send + Sync {
     /// Lists the databases on this server.
     async fn list_databases(&self) -> Result<Vec<Database>, crate::Error>;
 
-    /// Lists the [`SchemaId`]s on this server.
-    async fn list_available_schemas(&self) -> Result<Vec<SchemaId>, crate::Error>;
+    /// Lists the [`SchemaName`]s on this server.
+    async fn list_available_schemas(&self) -> Result<Vec<SchemaName>, crate::Error>;
 }
 
 /// A networking error.
@@ -305,17 +303,17 @@ pub enum Error {
         database_name: String,
 
         /// The schema provided for the database.
-        schema: SchemaId,
+        schema: SchemaName,
 
         /// The schema stored for the database.
-        stored_schema: SchemaId,
+        stored_schema: SchemaName,
     },
 
-    /// The [`SchemaId`] returned has already been registered with this server.
+    /// The [`SchemaName`] returned has already been registered with this server.
     #[error("schema '{0}' was already registered")]
-    SchemaAlreadyRegistered(SchemaId),
+    SchemaAlreadyRegistered(SchemaName),
 
-    /// The [`SchemaId`] requested was not registered with this server.
+    /// The [`SchemaName`] requested was not registered with this server.
     #[error("schema '{0}' is not registered with this server")]
-    SchemaNotRegistered(SchemaId),
+    SchemaNotRegistered(SchemaName),
 }

--- a/core/src/schema/collection.rs
+++ b/core/src/schema/collection.rs
@@ -1,55 +1,16 @@
-use std::{
-    borrow::Cow,
-    fmt::{Debug, Display},
+use std::fmt::Debug;
+
+use super::names::InvalidNameError;
+use crate::{
+    schema::{CollectionName, Schematic},
+    Error,
 };
-
-use serde::{Deserialize, Serialize};
-
-use crate::schema::Schematic;
-
-/// A unique collection id. Choose collection names that aren't likely to
-/// conflict with others, so that if someone mixes collections from multiple
-/// authors in a single database.
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
-#[serde(transparent)]
-#[allow(clippy::module_name_repetitions)]
-pub struct CollectionId(pub(crate) Cow<'static, str>);
-
-impl From<&'static str> for CollectionId {
-    fn from(str: &'static str) -> Self {
-        Self(Cow::from(str))
-    }
-}
-
-impl From<String> for CollectionId {
-    fn from(str: String) -> Self {
-        Self(Cow::from(str))
-    }
-}
-
-impl Display for CollectionId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl AsRef<str> for CollectionId {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
 
 /// A namespaced collection of `Document<Self>` items and views.
 pub trait Collection: Debug + Send + Sync {
     /// The `Id` of this collection.
-    fn collection_id() -> CollectionId;
+    fn collection_name() -> Result<CollectionName, InvalidNameError>;
 
     /// Defines all `View`s in this collection in `schema`.
-    fn define_views(schema: &mut Schematic);
-}
-
-#[test]
-fn test_id_conversions() {
-    assert_eq!(CollectionId::from("a").to_string(), "a");
-    assert_eq!(CollectionId::from(String::from("a")).to_string(), "a");
+    fn define_views(schema: &mut Schematic) -> Result<(), Error>;
 }

--- a/core/src/schema/names.rs
+++ b/core/src/schema/names.rs
@@ -1,0 +1,241 @@
+use std::{
+    borrow::Cow,
+    convert::{TryFrom, TryInto},
+    fmt::{Debug, Display, Write},
+    sync::Arc,
+};
+
+use serde::{Deserialize, Serialize};
+
+/// A valid schema name. Must be alphanumeric (`a-zA-Z9-0`) or a hyphen (`-`).
+/// Cloning this structure shares the underlying string data, regardless of
+/// whether it's a static string literal or an owned String.
+#[derive(Hash, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[serde(try_from = "String")]
+#[serde(into = "String")]
+pub struct Name(Arc<Cow<'static, str>>);
+
+/// An invalid name was used in a schema definition.
+#[derive(thiserror::Error, Debug, Serialize, Deserialize, Clone)]
+#[error("invalid name: {0}")]
+pub struct InvalidNameError(pub String);
+
+impl Name {
+    /// Creates a new name after validating it.
+    ///
+    /// # Errors
+    /// Returns [`InvalidNameError`] if the value passed contains any characters
+    /// other than `a-zA-Z9-0` or a hyphen (`-`).
+    pub fn new<T: TryInto<Self, Error = InvalidNameError>>(
+        contents: T,
+    ) -> Result<Self, InvalidNameError> {
+        contents.try_into()
+    }
+
+    fn validate_name(name: &str) -> Result<(), InvalidNameError> {
+        if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            Ok(())
+        } else {
+            Err(InvalidNameError(name.to_string()))
+        }
+    }
+}
+
+impl TryFrom<&'static str> for Name {
+    type Error = InvalidNameError;
+
+    fn try_from(value: &'static str) -> Result<Self, InvalidNameError> {
+        Self::validate_name(value)?;
+        Ok(Self(Arc::new(Cow::Borrowed(value))))
+    }
+}
+
+impl TryFrom<String> for Name {
+    type Error = InvalidNameError;
+
+    fn try_from(value: String) -> Result<Self, InvalidNameError> {
+        Self::validate_name(&value)?;
+        Ok(Self(Arc::new(Cow::Owned(value))))
+    }
+}
+
+#[allow(clippy::from_over_into)] // the auto into impl doesn't work with serde(into)
+impl Into<String> for Name {
+    fn into(self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// The owner of a schema item. This should represent the company, group, or
+/// individual that created the item in question. This value is used for
+/// namespacing. Changing this after values are in use is not supported without
+/// manual migrations at this time.
+#[derive(Hash, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[serde(transparent)]
+pub struct Authority(Name);
+
+impl TryFrom<&'static str> for Authority {
+    type Error = InvalidNameError;
+
+    fn try_from(value: &'static str) -> Result<Self, InvalidNameError> {
+        Ok(Self(Name::new(value)?))
+    }
+}
+
+impl TryFrom<String> for Authority {
+    type Error = InvalidNameError;
+
+    fn try_from(value: String) -> Result<Self, InvalidNameError> {
+        Ok(Self(Name::new(value)?))
+    }
+}
+
+impl Display for Authority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+/// The name of a [`Schema`](super::Schema).
+#[derive(Hash, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+pub struct SchemaName {
+    /// The authority of this schema.
+    pub authority: Authority,
+
+    /// The name of this schema.
+    pub name: Name,
+}
+
+impl SchemaName {
+    /// Creates a new schema name.
+    pub fn new<
+        A: TryInto<Authority, Error = InvalidNameError>,
+        N: TryInto<Name, Error = InvalidNameError>,
+    >(
+        authority: A,
+        name: N,
+    ) -> Result<Self, InvalidNameError> {
+        let authority = authority.try_into()?;
+        let name = name.try_into()?;
+        Ok(Self { authority, name })
+    }
+}
+
+impl Display for SchemaName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.authority, f)?;
+        f.write_char('.')?;
+        Display::fmt(&self.name, f)
+    }
+}
+
+impl TryFrom<&str> for SchemaName {
+    type Error = InvalidNameError;
+
+    fn try_from(schema_name: &str) -> Result<Self, InvalidNameError> {
+        let parts = schema_name.split('.').collect::<Vec<&str>>();
+        if parts.len() == 2 {
+            let mut parts = parts.into_iter();
+            let authority = parts.next().unwrap();
+            let name = parts.next().unwrap();
+
+            Self::new(authority.to_string(), name.to_string())
+        } else {
+            Err(InvalidNameError(schema_name.to_string()))
+        }
+    }
+}
+
+/// The name of a [`Collection`](super::Collection).
+#[derive(Hash, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+pub struct CollectionName {
+    /// The authority of this collection.
+    pub authority: Authority,
+
+    /// The name of this collection.
+    pub name: Name,
+}
+
+impl CollectionName {
+    /// Creates a new collection name.
+    pub fn new<
+        A: TryInto<Authority, Error = InvalidNameError>,
+        N: TryInto<Name, Error = InvalidNameError>,
+    >(
+        authority: A,
+        name: N,
+    ) -> Result<Self, InvalidNameError> {
+        let authority = authority.try_into()?;
+        let name = name.try_into()?;
+        Ok(Self { authority, name })
+    }
+}
+
+impl Display for CollectionName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.authority, f)?;
+        f.write_char('.')?;
+        Display::fmt(&self.name, f)
+    }
+}
+
+impl TryFrom<&str> for CollectionName {
+    type Error = InvalidNameError;
+
+    fn try_from(collection_name: &str) -> Result<Self, InvalidNameError> {
+        let parts = collection_name.split('.').collect::<Vec<&str>>();
+        if parts.len() == 2 {
+            let mut parts = parts.into_iter();
+            let authority = parts.next().unwrap();
+            let name = parts.next().unwrap();
+
+            Self::new(authority.to_string(), name.to_string())
+        } else {
+            Err(InvalidNameError(collection_name.to_string()))
+        }
+    }
+}
+
+/// The name of a [`View`](super::View).
+#[derive(Hash, PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+pub struct ViewName {
+    /// The name of the collection that contains this view.
+    pub collection: CollectionName,
+    /// The name of this view.
+    pub name: Name,
+}
+
+impl ViewName {
+    /// Creates a new view name.
+    pub fn new<
+        C: TryInto<CollectionName, Error = InvalidNameError>,
+        N: TryInto<Name, Error = InvalidNameError>,
+    >(
+        collection: C,
+        name: N,
+    ) -> Result<Self, InvalidNameError> {
+        let collection = collection.try_into()?;
+        let name = name.try_into()?;
+        Ok(Self { collection, name })
+    }
+}
+
+impl Display for ViewName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.collection, f)?;
+        f.write_char('.')?;
+        Display::fmt(&self.name, f)
+    }
+}
+
+#[test]
+fn name_validation_tests() {
+    assert!(Name::new("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-").is_ok());
+    assert!(matches!(Name::new("."), Err(InvalidNameError(_))));
+}

--- a/core/src/transaction.rs
+++ b/core/src/transaction.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{document::Header, schema::CollectionId};
+use crate::{document::Header, schema::CollectionName};
 
 /// A list of operations to execute as a single unit. If any operation fails,
 /// all changes are aborted. Reads that happen while the transaction is in
@@ -24,7 +24,7 @@ impl<'a> Transaction<'a> {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct Operation<'a> {
     /// The id of the `Collection`.
-    pub collection: CollectionId,
+    pub collection: CollectionName,
 
     /// The command being performed.
     pub command: Command<'a>,
@@ -68,7 +68,7 @@ pub enum OperationResult {
     /// A `Document` was updated.
     DocumentUpdated {
         /// The id of the `Collection` of the updated `Document`.
-        collection: CollectionId,
+        collection: CollectionName,
 
         /// The header of the updated `Document`.
         header: Header,
@@ -77,7 +77,7 @@ pub enum OperationResult {
     /// A `Document` was deleted.
     DocumentDeleted {
         /// The id of the `Collection` of the deleted `Document`.
-        collection: CollectionId,
+        collection: CollectionName,
 
         /// The id of the deleted `Document`.
         id: u64,
@@ -109,7 +109,7 @@ impl<'a> Executed<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChangedDocument {
     /// The id of the `Collection` of the changed `Document`.
-    pub collection: CollectionId,
+    pub collection: CollectionName,
 
     /// The id of the changed `Document`.
     pub id: u64,

--- a/generate-code-coverage.sh
+++ b/generate-code-coverage.sh
@@ -3,10 +3,12 @@ echo "Executing tests"
 CARGO_INCREMENTAL=0 LLVM_PROFILE_FILE="%m.profraw" RUSTFLAGS="-Zinstrument-coverage" RUSTDOCFLAGS="-Cpanic=abort" cargo +nightly test --all-features
 echo "Generating coverage report"
 grcov . --binary-path ./target/debug/ -s . -t html --branch --ignore-not-existing --llvm -o coverage/
+COVERAGE=`cat coverage/index.html | grep -oP '\d+(\.\d+)? %' | head -n1`
 if command -v cargo-badge &> /dev/null
 then
     echo "Generating badge"
-    cargo badge -s "coverage" "`cat coverage/index.html | grep -oP '\d+(\.\d+)? %' | head -n1`" -o coverage/badge.svg
+    cargo badge -s "coverage" "$COVERAGE" -o coverage/badge.svg
 fi
+echo "::warning::Line Coverage Percentage: $COVERAGE"
 echo "Cleaning up."
 find . -name "*.profraw" -exec rm {} \;

--- a/local/benches/basics.rs
+++ b/local/benches/basics.rs
@@ -29,8 +29,9 @@ use std::{borrow::Cow, sync::Arc};
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use pliantdb_core::{
     connection::Connection,
-    schema::{Collection, CollectionId, Schematic},
+    schema::{Collection, CollectionName, InvalidNameError, Schematic},
     test_util::TestDirectory,
+    Error,
 };
 use pliantdb_local::{Configuration, Storage};
 use serde::{Deserialize, Serialize};
@@ -42,11 +43,13 @@ struct ResizableDocument<'a> {
 }
 
 impl<'a> Collection for ResizableDocument<'a> {
-    fn collection_id() -> CollectionId {
-        CollectionId::from("resizable-docs")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("khonsulabs", "resizable-docs")
     }
 
-    fn define_views(_schema: &mut Schematic) {}
+    fn define_views(_schema: &mut Schematic) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 async fn save_document(doc: &ResizableDocument<'_>, db: &Storage<ResizableDocument<'static>>) {

--- a/local/src/backup.rs
+++ b/local/src/backup.rs
@@ -20,6 +20,7 @@
 
 use std::{
     borrow::Cow,
+    convert::TryFrom,
     ffi::OsString,
     path::{Path, PathBuf},
     str::FromStr,
@@ -28,7 +29,7 @@ use std::{
 use flume::Receiver;
 use pliantdb_core::{
     document::{Document, Header, Revision},
-    schema::{CollectionId, Key, Schema},
+    schema::{CollectionName, Key, Schema},
 };
 use structopt::StructOpt;
 use tokio::{
@@ -59,7 +60,7 @@ pub enum Command {
     ///
     /// This command will create a single folder within `output_directory` named
     /// `output_name`. Within that folder, one subfolder will be created for
-    /// each collection [`CollectionId`]. Each folder will contain files named
+    /// each collection [`CollectionName`]. Each folder will contain files named
     /// `<Document.header.id>.<Document.header.revision.id>`, and the files will
     /// contain the raw bytes stored inside of the documents. Assuming you're
     /// using the built in Serialization, the data will be in the
@@ -172,7 +173,7 @@ impl Command {
                 .unwrap()
                 .to_str()
                 .expect("invalid collection name encountered");
-            let collection = CollectionId::from(collection.to_owned());
+            let collection = CollectionName::try_from(collection)?;
             println!("Restoring {}", collection);
 
             let mut entries = tokio::fs::read_dir(&collection_folder).await?;
@@ -219,7 +220,7 @@ async fn write_documents(
     }
 
     while let Ok(document) = receiver.recv_async().await {
-        let collection_directory = backup.join(document.collection.as_ref());
+        let collection_directory = backup.join(document.collection.to_string());
         if !collection_directory.exists() {
             tokio::fs::create_dir(&collection_directory).await?;
         }

--- a/local/src/error.rs
+++ b/local/src/error.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use pliantdb_core::schema::view;
+use pliantdb_core::schema::{view, InvalidNameError};
 
 /// Errors that can occur from interacting with storage.
 #[derive(thiserror::Error, Debug)]
@@ -37,6 +37,12 @@ pub enum Error {
 impl From<Error> for pliantdb_core::Error {
     fn from(err: Error) -> Self {
         Self::Storage(err.to_string())
+    }
+}
+
+impl From<InvalidNameError> for Error {
+    fn from(err: InvalidNameError) -> Self {
+        Self::Core(pliantdb_core::Error::from(err))
     }
 }
 

--- a/local/src/open_trees.rs
+++ b/local/src/open_trees.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use pliantdb_core::schema::{CollectionId, Schematic};
+use pliantdb_core::schema::{CollectionName, Schematic};
 
-use crate::{storage::document_tree_name, views::view_invalidated_docs_tree_name};
+use crate::{storage::document_tree_name, views::view_invalidated_docs_tree_name, Error};
 
 #[derive(Default)]
 pub struct OpenTrees {
@@ -26,17 +26,17 @@ impl OpenTrees {
     pub fn open_trees_for_document_change(
         &mut self,
         sled: &sled::Db,
-        collection: &CollectionId,
+        collection: &CollectionName,
         schema: &Schematic,
-    ) -> Result<(), sled::Error> {
+    ) -> Result<(), Error> {
         self.open_tree(sled, &document_tree_name(collection))?;
 
         if let Some(views) = schema.views_in_collection(collection) {
             for view in views {
-                let view_name = view.name();
+                let view_name = view.view_name()?;
                 self.open_tree(
                     sled,
-                    &view_invalidated_docs_tree_name(collection, view_name.as_ref()),
+                    &view_invalidated_docs_tree_name(collection, &view_name),
                 )?;
             }
         }

--- a/local/src/views.rs
+++ b/local/src/views.rs
@@ -1,4 +1,6 @@
-use pliantdb_core::schema::CollectionId;
+use std::fmt::Display;
+
+use pliantdb_core::schema::CollectionName;
 use serde::{Deserialize, Serialize};
 
 use self::{integrity_scanner::IntegrityScan, mapper::Map};
@@ -19,24 +21,33 @@ pub struct EntryMapping {
 pub mod integrity_scanner;
 pub mod mapper;
 
-pub fn view_entries_tree_name(collection: &CollectionId, view_name: &str) -> String {
+pub fn view_entries_tree_name(collection: &CollectionName, view_name: &impl Display) -> String {
     format!("{}::{}", collection, view_name)
 }
 
 /// Used to store Document ID -> Key mappings, so that when a document is updated, we can remove the old entry.
-pub fn view_document_map_tree_name(collection: &CollectionId, view_name: &str) -> String {
+pub fn view_document_map_tree_name(
+    collection: &CollectionName,
+    view_name: &impl Display,
+) -> String {
     format!("{}::{}::document-map", collection, view_name)
 }
 
-pub fn view_invalidated_docs_tree_name(collection: &CollectionId, view_name: &str) -> String {
+pub fn view_invalidated_docs_tree_name(
+    collection: &CollectionName,
+    view_name: &impl Display,
+) -> String {
     format!("{}::{}::invalidated", collection, view_name)
 }
 
-pub fn view_omitted_docs_tree_name(collection: &CollectionId, view_name: &str) -> String {
+pub fn view_omitted_docs_tree_name(
+    collection: &CollectionName,
+    view_name: &impl Display,
+) -> String {
     format!("{}::{}::omitted", collection, view_name)
 }
 
-pub fn view_versions_tree_name(collection: &CollectionId) -> String {
+pub fn view_versions_tree_name(collection: &CollectionName) -> String {
     format!("{}::view-versions", collection)
 }
 

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use pliantdb_core::{
     connection::Connection,
     document::Document,
-    schema::{view, view::map, CollectionId, Key, Schema},
+    schema::{view, view::map, CollectionName, Key, Schema, ViewName},
 };
 use pliantdb_jobs::{Job, Keyed};
 use sled::{
@@ -12,11 +12,13 @@ use sled::{
     IVec, Transactional, Tree,
 };
 
-use super::{
-    view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
-    view_omitted_docs_tree_name, EntryMapping, Task, ViewEntry,
+use crate::{
+    storage::{document_tree_name, Storage},
+    views::{
+        view_document_map_tree_name, view_entries_tree_name, view_invalidated_docs_tree_name,
+        view_omitted_docs_tree_name, EntryMapping, Task, ViewEntry,
+    },
 };
-use crate::storage::{document_tree_name, Storage};
 
 #[derive(Debug)]
 pub struct Mapper<DB> {
@@ -26,8 +28,8 @@ pub struct Mapper<DB> {
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub struct Map {
-    pub collection: CollectionId,
-    pub view_name: Cow<'static, str>,
+    pub collection: CollectionName,
+    pub view_name: ViewName,
 }
 
 #[async_trait]

--- a/pliantdb/examples/basic-local.rs
+++ b/pliantdb/examples/basic-local.rs
@@ -3,11 +3,11 @@ use std::time::SystemTime;
 use pliantdb::{
     core::{
         connection::Connection,
-        schema::{Collection, Schematic},
+        schema::{Collection, CollectionName, InvalidNameError, Schematic},
+        Error,
     },
     local::{Configuration, Storage},
 };
-use pliantdb_core::schema::CollectionId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,11 +17,13 @@ struct Message {
 }
 
 impl Collection for Message {
-    fn collection_id() -> CollectionId {
-        CollectionId::from("messages")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("khonsulabs", "messages")
     }
 
-    fn define_views(_schema: &mut Schematic) {}
+    fn define_views(_schema: &mut Schematic) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 #[tokio::main]

--- a/pliantdb/examples/server.rs
+++ b/pliantdb/examples/server.rs
@@ -2,9 +2,11 @@
 
 use std::{path::Path, time::Duration};
 
-use pliantdb_client::{url::Url, Client};
-use pliantdb_core::{connection::Connection, networking::ServerConnection, schema::Schema, Error};
-use pliantdb_server::{Configuration, Server};
+use pliantdb::{
+    client::{url::Url, Client},
+    core::{connection::Connection, networking::ServerConnection, schema::Schema, Error},
+    server::{Configuration, Server},
+};
 use rand::{thread_rng, Rng};
 
 mod support;
@@ -21,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
     let certificate = server.certificate().await?;
     server.register_schema::<Shape>().await?;
     match server
-        .create_database("my-database", Shape::schema_id())
+        .create_database("my-database", Shape::schema_name()?)
         .await
     {
         Ok(()) => {}
@@ -58,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
             Client::new(&Url::parse("ws://localhost:8080")?, None)
                 .await?
                 .database::<Shape>("my-database")
-                .await,
+                .await?,
             "websockets",
         ));
     }
@@ -72,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?
         .database::<Shape>("my-database")
-        .await,
+        .await?,
         "pliantdb",
     ));
 

--- a/pliantdb/examples/support/schema.rs
+++ b/pliantdb/examples/support/schema.rs
@@ -1,8 +1,10 @@
-use std::borrow::Cow;
-
 use pliantdb_core::{
     document::Document,
-    schema::{view, Collection, CollectionId, MapResult, MappedValue, Schematic, View},
+    schema::{
+        view, Collection, CollectionName, InvalidNameError, MapResult, MappedValue, Name,
+        Schematic, View,
+    },
+    Error,
 };
 use serde::{Deserialize, Serialize};
 
@@ -18,12 +20,12 @@ impl Shape {
 }
 
 impl Collection for Shape {
-    fn collection_id() -> CollectionId {
-        CollectionId::from("shapes")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("khonsulabs", "shapes")
     }
 
-    fn define_views(schema: &mut Schematic) {
-        schema.define_view(ShapesByNumberOfSides);
+    fn define_views(schema: &mut Schematic) -> Result<(), Error> {
+        schema.define_view(ShapesByNumberOfSides)
     }
 }
 
@@ -41,8 +43,8 @@ impl View for ShapesByNumberOfSides {
         1
     }
 
-    fn name(&self) -> Cow<'static, str> {
-        Cow::from("by-number-of-sides")
+    fn name(&self) -> Result<Name, InvalidNameError> {
+        Name::new("by-number-of-sides")
     }
 
     fn map(&self, document: &Document<'_>) -> MapResult<Self::Key, Self::Value> {

--- a/pliantdb/examples/view-examples.rs
+++ b/pliantdb/examples/view-examples.rs
@@ -1,10 +1,12 @@
-use std::borrow::Cow;
-
 use pliantdb::{
     core::{
         connection::Connection,
         document::Document,
-        schema::{view, Collection, CollectionId, MapResult, MappedValue, Schematic, View},
+        schema::{
+            view, Collection, CollectionName, InvalidNameError, MapResult, MappedValue, Name,
+            Schematic, View,
+        },
+        Error,
     },
     local::{Configuration, Storage},
 };
@@ -22,12 +24,12 @@ impl Shape {
 }
 
 impl Collection for Shape {
-    fn collection_id() -> CollectionId {
-        CollectionId::from("shapes")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("khonsulabs", "shapes")
     }
 
-    fn define_views(schema: &mut Schematic) {
-        schema.define_view(ShapesByNumberOfSides);
+    fn define_views(schema: &mut Schematic) -> Result<(), Error> {
+        schema.define_view(ShapesByNumberOfSides)
     }
 }
 
@@ -45,8 +47,8 @@ impl View for ShapesByNumberOfSides {
         1
     }
 
-    fn name(&self) -> Cow<'static, str> {
-        Cow::from("by-number-of-sides")
+    fn name(&self) -> Result<Name, InvalidNameError> {
+        Name::new("by-number-of-sides")
     }
 
     fn map(&self, document: &Document<'_>) -> MapResult<Self::Key, Self::Value> {

--- a/server/src/admin/database.rs
+++ b/server/src/admin/database.rs
@@ -1,21 +1,19 @@
-use std::borrow::Cow;
-
-use pliantdb_core::schema::CollectionId;
-use pliantdb_local::core::{
+use pliantdb_core::{
     document::Document,
-    schema::{self, Collection, Schematic, View},
+    schema::{self, Collection, CollectionName, InvalidNameError, Name, Schematic, View},
+    Error,
 };
 
 #[derive(Debug)]
 pub struct Database;
 
 impl Collection for Database {
-    fn collection_id() -> CollectionId {
-        CollectionId::from("pliantdb.databases")
+    fn collection_name() -> Result<CollectionName, InvalidNameError> {
+        CollectionName::new("pliantdb", "databases")
     }
 
-    fn define_views(schema: &mut Schematic) {
-        schema.define_view(ByName);
+    fn define_views(schema: &mut Schematic) -> Result<(), Error> {
+        schema.define_view(ByName)
     }
 }
 
@@ -25,14 +23,14 @@ pub struct ByName;
 impl View for ByName {
     type Collection = Database;
     type Key = String;
-    type Value = schema::SchemaId;
+    type Value = schema::SchemaName;
 
     fn version(&self) -> u64 {
         1
     }
 
-    fn name(&self) -> Cow<'static, str> {
-        Cow::from("by-name")
+    fn name(&self) -> Result<Name, InvalidNameError> {
+        Name::new("by-name")
     }
 
     fn map(&self, document: &Document<'_>) -> schema::MapResult<Self::Key, Self::Value> {

--- a/server/src/admin/mod.rs
+++ b/server/src/admin/mod.rs
@@ -1,5 +1,7 @@
-use pliantdb_core::schema::{self, Schema};
-use schema::SchemaId;
+use pliantdb_core::{
+    schema::{InvalidNameError, Schema, SchemaName},
+    Error,
+};
 
 pub mod database;
 
@@ -7,11 +9,13 @@ pub mod database;
 pub struct Admin;
 
 impl Schema for Admin {
-    fn schema_id() -> SchemaId {
-        SchemaId::from("pliantdb.admin")
+    fn schema_name() -> Result<SchemaName, InvalidNameError> {
+        SchemaName::new("khonsulabs", "pliantdb.admin")
     }
 
-    fn define_collections(schema: &mut pliantdb_local::core::schema::Schematic) {
-        schema.define_collection::<database::Database>();
+    fn define_collections(
+        schema: &mut pliantdb_local::core::schema::Schematic,
+    ) -> Result<(), Error> {
+        schema.define_collection::<database::Database>()
     }
 }

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use pliantdb_core::networking::{self, fabruic};
 use pliantdb_local::core::{self, schema};
-use schema::SchemaId;
+use schema::{InvalidNameError, SchemaName};
 
 /// An error occurred while interacting with a [`Server`](crate::Server).
 #[derive(Debug, thiserror::Error)]
@@ -48,15 +48,15 @@ pub enum Error {
         database_name: String,
 
         /// The schema provided for the database.
-        schema: SchemaId,
+        schema: SchemaName,
 
         /// The schema stored for the database.
-        stored_schema: SchemaId,
+        stored_schema: SchemaName,
     },
 
-    /// The [`SchemaId`] returned has already been registered with this server.
+    /// The [`SchemaName`] returned has already been registered with this server.
     #[error("schema '{0}' was already registered")]
-    SchemaAlreadyRegistered(SchemaId),
+    SchemaAlreadyRegistered(SchemaName),
 
     /// An error occurred from within the schema.
     #[error("error from core {0}")]
@@ -101,6 +101,12 @@ impl From<Error> for core::Error {
                 Self::Networking(networking::Error::SchemaAlreadyRegistered(id))
             }
         }
+    }
+}
+
+impl From<InvalidNameError> for Error {
+    fn from(err: InvalidNameError) -> Self {
+        Self::Core(core::Error::InvalidName(err))
     }
 }
 

--- a/server/src/test_util.rs
+++ b/server/src/test_util.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use pliantdb_core::{
     networking::ServerConnection,
-    schema::{Schema, SchemaId},
+    schema::{Schema, SchemaName},
     test_util::Basic,
 };
 
@@ -19,26 +19,28 @@ pub async fn initialize_basic_server(path: &Path) -> anyhow::Result<Server> {
         .install_self_signed_certificate(BASIC_SERVER_NAME, false)
         .await?;
 
-    server.create_database("tests", Basic::schema_id()).await?;
+    server
+        .create_database("tests", Basic::schema_name()?)
+        .await?;
 
     Ok(server)
 }
 
 pub async fn basic_server_connection_tests<C: ServerConnection>(server: C) -> anyhow::Result<()> {
     let schemas = server.list_available_schemas().await?;
-    assert_eq!(schemas, vec![Basic::schema_id()]);
+    assert_eq!(schemas, vec![Basic::schema_name()?]);
 
     let databases = server.list_databases().await?;
     assert_eq!(
         databases,
         vec![pliantdb_core::networking::Database {
             name: String::from("tests"),
-            schema: Basic::schema_id()
+            schema: Basic::schema_name()?
         }]
     );
 
     server
-        .create_database("another-db", Basic::schema_id())
+        .create_database("another-db", Basic::schema_name()?)
         .await?;
     server.delete_database("another-db").await?;
 
@@ -50,7 +52,7 @@ pub async fn basic_server_connection_tests<C: ServerConnection>(server: C) -> an
     ));
 
     assert!(matches!(
-        server.create_database("tests", Basic::schema_id()).await,
+        server.create_database("tests", Basic::schema_name()?).await,
         Err(pliantdb_core::Error::Networking(
             pliantdb_core::networking::Error::DatabaseNameAlreadyTaken(_)
         ))
@@ -58,7 +60,7 @@ pub async fn basic_server_connection_tests<C: ServerConnection>(server: C) -> an
 
     assert!(matches!(
         server
-            .create_database("|invalidname", Basic::schema_id())
+            .create_database("|invalidname", Basic::schema_name()?)
             .await,
         Err(pliantdb_core::Error::Networking(
             pliantdb_core::networking::Error::InvalidDatabaseName(_)
@@ -67,7 +69,7 @@ pub async fn basic_server_connection_tests<C: ServerConnection>(server: C) -> an
 
     assert!(matches!(
         server
-            .create_database("another-db", SchemaId::from("unknown schema"))
+            .create_database("another-db", SchemaName::new("unknown", "unknown-schema")?)
             .await,
         Err(pliantdb_core::Error::Networking(
             pliantdb_core::networking::Error::SchemaNotRegistered(_)


### PR DESCRIPTION
Refs #39.

The full goals of this PR:

* [x] Enforce some naming consistency on all schema names.
* [x] Enforce namespacing for views and collections and schemas.
