### PR TITLE
Add WebAssembly Client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,15 +107,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install code coverage requirements
-        run: |
-          rustup component add llvm-tools-preview
-          rustup install nightly
-          curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
-
       - name: Run code coverage
         run: |
-          PATH=".:$PATH" cargo xtask generate-code-coverage-report
+          cargo xtask generate-code-coverage-report --install-dependencies
 
       - name: Deploy Docs
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install code coverage requirements
         run: |
           rustup component add llvm-tools-preview
-          rustup install nightly-2021-03-25
+          rustup install nightly
           curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
 
       - name: Run code coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ members = [
 
 [patch.crates-io]
 # fabruic = { path = "../fabruic", version = "0.0.1-dev.2" }
-actionable = { git = "https://github.com/khonsulabs/actionable.git", branch = "main", version = "0.1.0-dev.2" }
+# actionable = { git = "https://github.com/khonsulabs/actionable.git", branch = "main", version = "0.1.0-dev.2" }

--- a/circulate/Cargo.toml
+++ b/circulate/Cargo.toml
@@ -11,15 +11,21 @@ categories = ["asynchronous"]
 readme = "./README.md"
 
 [dependencies]
-tokio = { version = "1", features = ["sync", "macros", "rt"] }
 flume = "0.10"
-serde = { version = "1", features = ["derive"] }
+serde = { version="1", features=["derive"] }
 serde_cbor = "0.11"
 futures = "0.3"
+async-lock = "2"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4"
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+tokio = { version="1", features=["sync", "macros", "rt"] }
 
 [dev-dependencies]
 anyhow = "1"
-tokio = { version = "1", features = [
+tokio = { version="1", features=[
     "sync",
     "rt",
     "rt-multi-thread",

--- a/circulate/src/lib.rs
+++ b/circulate/src/lib.rs
@@ -212,7 +212,7 @@ impl Relay {
 
     async fn topic_id(&self, topic: &str) -> Option<TopicId> {
         let topics = self.data.topics.read().await;
-        topics.get(topic).cloned()
+        topics.get(topic).copied()
     }
 
     async fn post_message_to_topic(&self, message: Message, topic: TopicId) {

--- a/circulate/src/lib.rs
+++ b/circulate/src/lib.rs
@@ -96,6 +96,8 @@ impl Relay {
                 id,
                 receiver,
                 relay: self.clone(),
+                #[cfg(not(target_arch = "wasm32"))]
+                tokio: tokio::runtime::Handle::current(),
             }),
         }
     }
@@ -315,6 +317,8 @@ struct SubscriberData {
     id: SubscriberId,
     relay: Relay,
     receiver: flume::Receiver<Arc<Message>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    tokio: tokio::runtime::Handle,
 }
 
 impl Drop for SubscriberData {
@@ -327,8 +331,7 @@ impl Drop for SubscriberData {
         #[cfg(target_arch = "wasm32")]
         wasm_bindgen_futures::spawn_local(drop_task);
         #[cfg(not(target_arch = "wasm32"))]
-        // TODO Replace with a tokio runtime handle instead of global tokio::spawn
-        tokio::spawn(drop_task);
+        self.tokio.spawn(drop_task);
     }
 }
 

--- a/circulate/src/lib.rs
+++ b/circulate/src/lib.rs
@@ -21,9 +21,9 @@ use std::{
     },
 };
 
+use async_lock::RwLock;
 pub use flume;
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
 
 /// A `PubSub` message.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -321,133 +321,142 @@ impl Drop for SubscriberData {
     fn drop(&mut self) {
         let id = self.id;
         let relay = self.relay.clone();
-        // TODO Replace with a tokio runtime handle instead of global tokio::spawn
-        tokio::spawn(async move {
+        let drop_task = async move {
             relay.unsubscribe_all(id).await;
-        });
+        };
+        #[cfg(target_arch = "wasm32")]
+        wasm_bindgen_futures::spawn_local(drop_task);
+        #[cfg(not(target_arch = "wasm32"))]
+        // TODO Replace with a tokio runtime handle instead of global tokio::spawn
+        tokio::spawn(drop_task);
     }
 }
 
-#[tokio::test]
-async fn simple_pubsub_test() -> anyhow::Result<()> {
-    let pubsub = Relay::default();
-    let subscriber = pubsub.create_subscriber().await;
-    subscriber.subscribe_to("mytopic").await;
-    pubsub.publish("mytopic", &String::from("test")).await?;
-    let receiver = subscriber.receiver().clone();
-    let message = receiver.recv_async().await.expect("No message received");
-    assert_eq!(message.topic, "mytopic");
-    assert_eq!(message.payload::<String>()?, "test");
-    // The message should only be received once.
-    assert!(matches!(
-        tokio::task::spawn_blocking(
-            move || receiver.recv_timeout(std::time::Duration::from_millis(100))
-        )
-        .await,
-        Ok(Err(_))
-    ));
-    Ok(())
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[tokio::test]
-async fn multiple_subscribers_test() -> anyhow::Result<()> {
-    let pubsub = Relay::default();
-    let subscriber_a = pubsub.create_subscriber().await;
-    let subscriber_ab = pubsub.create_subscriber().await;
-    subscriber_a.subscribe_to("a").await;
-    subscriber_ab.subscribe_to("a").await;
-    subscriber_ab.subscribe_to("b").await;
+    #[tokio::test]
+    async fn simple_pubsub_test() -> anyhow::Result<()> {
+        let pubsub = Relay::default();
+        let subscriber = pubsub.create_subscriber().await;
+        subscriber.subscribe_to("mytopic").await;
+        pubsub.publish("mytopic", &String::from("test")).await?;
+        let receiver = subscriber.receiver().clone();
+        let message = receiver.recv_async().await.expect("No message received");
+        assert_eq!(message.topic, "mytopic");
+        assert_eq!(message.payload::<String>()?, "test");
+        // The message should only be received once.
+        assert!(matches!(
+            tokio::task::spawn_blocking(
+                move || receiver.recv_timeout(std::time::Duration::from_millis(100))
+            )
+            .await,
+            Ok(Err(_))
+        ));
+        Ok(())
+    }
 
-    pubsub.publish("a", &String::from("a1")).await?;
-    pubsub.publish("b", &String::from("b1")).await?;
-    pubsub.publish("a", &String::from("a2")).await?;
+    #[tokio::test]
+    async fn multiple_subscribers_test() -> anyhow::Result<()> {
+        let pubsub = Relay::default();
+        let subscriber_a = pubsub.create_subscriber().await;
+        let subscriber_ab = pubsub.create_subscriber().await;
+        subscriber_a.subscribe_to("a").await;
+        subscriber_ab.subscribe_to("a").await;
+        subscriber_ab.subscribe_to("b").await;
 
-    // Check subscriber_a for a1 and a2.
-    let message = subscriber_a.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a1");
-    let message = subscriber_a.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a2");
+        pubsub.publish("a", &String::from("a1")).await?;
+        pubsub.publish("b", &String::from("b1")).await?;
+        pubsub.publish("a", &String::from("a2")).await?;
 
-    let message = subscriber_ab.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a1");
-    let message = subscriber_ab.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "b1");
-    let message = subscriber_ab.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a2");
+        // Check subscriber_a for a1 and a2.
+        let message = subscriber_a.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a1");
+        let message = subscriber_a.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a2");
 
-    Ok(())
-}
+        let message = subscriber_ab.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a1");
+        let message = subscriber_ab.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "b1");
+        let message = subscriber_ab.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a2");
 
-#[tokio::test]
-async fn unsubscribe_test() -> anyhow::Result<()> {
-    let pubsub = Relay::default();
-    let subscriber = pubsub.create_subscriber().await;
-    subscriber.subscribe_to("a").await;
+        Ok(())
+    }
 
-    pubsub.publish("a", &String::from("a1")).await?;
-    subscriber.unsubscribe_from("a").await;
-    pubsub.publish("a", &String::from("a2")).await?;
-    subscriber.subscribe_to("a").await;
-    pubsub.publish("a", &String::from("a3")).await?;
+    #[tokio::test]
+    async fn unsubscribe_test() -> anyhow::Result<()> {
+        let pubsub = Relay::default();
+        let subscriber = pubsub.create_subscriber().await;
+        subscriber.subscribe_to("a").await;
 
-    // Check subscriber_a for a1 and a2.
-    let message = subscriber.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a1");
-    let message = subscriber.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a3");
+        pubsub.publish("a", &String::from("a1")).await?;
+        subscriber.unsubscribe_from("a").await;
+        pubsub.publish("a", &String::from("a2")).await?;
+        subscriber.subscribe_to("a").await;
+        pubsub.publish("a", &String::from("a3")).await?;
 
-    Ok(())
-}
+        // Check subscriber_a for a1 and a2.
+        let message = subscriber.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a1");
+        let message = subscriber.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a3");
 
-#[tokio::test]
-async fn drop_and_send_test() -> anyhow::Result<()> {
-    let pubsub = Relay::default();
-    let subscriber_a = pubsub.create_subscriber().await;
-    let subscriber_to_drop = pubsub.create_subscriber().await;
-    subscriber_a.subscribe_to("a").await;
-    subscriber_to_drop.subscribe_to("a").await;
+        Ok(())
+    }
 
-    pubsub.publish("a", &String::from("a1")).await?;
-    drop(subscriber_to_drop);
-    pubsub.publish("a", &String::from("a2")).await?;
+    #[tokio::test]
+    async fn drop_and_send_test() -> anyhow::Result<()> {
+        let pubsub = Relay::default();
+        let subscriber_a = pubsub.create_subscriber().await;
+        let subscriber_to_drop = pubsub.create_subscriber().await;
+        subscriber_a.subscribe_to("a").await;
+        subscriber_to_drop.subscribe_to("a").await;
 
-    // Check subscriber_a for a1 and a2.
-    let message = subscriber_a.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a1");
-    let message = subscriber_a.receiver().recv_async().await?;
-    assert_eq!(message.payload::<String>()?, "a2");
+        pubsub.publish("a", &String::from("a1")).await?;
+        drop(subscriber_to_drop);
+        pubsub.publish("a", &String::from("a2")).await?;
 
-    let subscribers = pubsub.data.subscribers.read().await;
-    assert_eq!(subscribers.len(), 1);
-    let topics = pubsub.data.topics.read().await;
-    let topic_id = topics.get("a").expect("topic not found");
-    let subscriptions = pubsub.data.subscriptions.read().await;
-    assert_eq!(
-        subscriptions
-            .get(topic_id)
-            .expect("subscriptions not found")
-            .len(),
-        1
-    );
+        // Check subscriber_a for a1 and a2.
+        let message = subscriber_a.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a1");
+        let message = subscriber_a.receiver().recv_async().await?;
+        assert_eq!(message.payload::<String>()?, "a2");
 
-    Ok(())
-}
+        let subscribers = pubsub.data.subscribers.read().await;
+        assert_eq!(subscribers.len(), 1);
+        let topics = pubsub.data.topics.read().await;
+        let topic_id = topics.get("a").expect("topic not found");
+        let subscriptions = pubsub.data.subscriptions.read().await;
+        assert_eq!(
+            subscriptions
+                .get(topic_id)
+                .expect("subscriptions not found")
+                .len(),
+            1
+        );
 
-#[tokio::test]
-async fn drop_cleanup_test() -> anyhow::Result<()> {
-    let pubsub = Relay::default();
-    let subscriber = pubsub.create_subscriber().await;
-    subscriber.subscribe_to("a").await;
-    drop(subscriber);
-    // Drop spawns a task that cleans up. Give it a moment to execute.
-    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        Ok(())
+    }
 
-    let subscribers = pubsub.data.subscribers.read().await;
-    assert_eq!(subscribers.len(), 0);
-    let subscriptions = pubsub.data.subscriptions.read().await;
-    assert_eq!(subscriptions.len(), 0);
-    let topics = pubsub.data.topics.read().await;
-    assert_eq!(topics.len(), 0);
+    #[tokio::test]
+    async fn drop_cleanup_test() -> anyhow::Result<()> {
+        let pubsub = Relay::default();
+        let subscriber = pubsub.create_subscriber().await;
+        subscriber.subscribe_to("a").await;
+        drop(subscriber);
+        // Drop spawns a task that cleans up. Give it a moment to execute.
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-    Ok(())
+        let subscribers = pubsub.data.subscribers.read().await;
+        assert_eq!(subscribers.len(), 0);
+        let subscriptions = pubsub.data.subscriptions.read().await;
+        assert_eq!(subscriptions.len(), 0);
+        let topics = pubsub.data.topics.read().await;
+        assert_eq!(topics.len(), 0);
+
+        Ok(())
+    }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,6 +43,7 @@ web-sys = { version="0.3", features=[
     "MessageEvent",
     "ProgressEvent",
     "WebSocket",
+    "CloseEvent",
 ] }
 wasm-bindgen-futures = "0.4"
 wasm-bindgen = "0.2"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [features]
 default = ["full"]
 full = ["websockets", "trusted-dns", "pubsub", "keyvalue"]
-websockets = ["pliantdb-core/websockets", "tokio", "tokio-tungstenite", "bincode"]
+websockets = ["pliantdb-core/websockets", "tokio-tungstenite", "bincode"]
 trusted-dns = ["fabruic/trust-dns"]
 pubsub = ["pliantdb-core/pubsub"]
 keyvalue = ["pliantdb-core/keyvalue"]
@@ -49,7 +49,7 @@ wasm-bindgen = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fabruic = { version="0.0.1-dev.2" }
-tokio = { version="1", features=["sync"], optional=true }
+tokio = { version="1", features=["sync"] }
 tokio-tungstenite = { version="0.14", optional=true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,25 +13,47 @@ readme = "../README.md"
 [features]
 default = ["full"]
 full = ["websockets", "trusted-dns", "pubsub", "keyvalue"]
-websockets = ["pliantdb-core/websockets", "tokio-tungstenite", "bincode"]
-trusted-dns = ["pliantdb-core/trusted-dns"]
+websockets = ["pliantdb-core/websockets", "tokio", "tokio-tungstenite", "bincode"]
+trusted-dns = ["fabruic/trust-dns"]
 pubsub = ["pliantdb-core/pubsub"]
 keyvalue = ["pliantdb-core/keyvalue"]
 test-util = []
 
 [dependencies]
-pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false, features = ["networking"] }
+pliantdb-core = { path="../core", version="0.1.0-dev.3", default-features=false, features=["networking"] }
 thiserror = "1"
 url = "2.2"
 flume = "0.10"
-tokio = { version = "1", features = ["sync", "macros"] }
 futures = "0.3"
 async-trait = "0.1"
 once_cell = "1"
 serde = "1"
 serde_cbor = "0.11"
-tokio-tungstenite = { version = "0.14", optional = true }
-bincode = { version = "1", optional = true }
+bincode = { version="1", optional=true }
+async-lock = "2"
+js-sys = "0.3"
+log = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version="0.3", features=[
+    "BinaryType",
+    "Blob",
+    "ErrorEvent",
+    "FileReader",
+    "MessageEvent",
+    "ProgressEvent",
+    "WebSocket",
+] }
+wasm-bindgen-futures = "0.4"
+wasm-bindgen = "0.2"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+fabruic = { version="0.0.1-dev.2" }
+tokio = { version="1", features=["sync"], optional=true }
+tokio-tungstenite = { version="0.14", optional=true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version="1", features=["sync", "macros"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -217,11 +217,11 @@ impl<A: CustomApi> Client<A> {
         let subscribers = SubscriberMap::default();
 
         wasm_websocket_worker::reconnecting_client_loop(
-            url,
+            Arc::new(url),
             request_receiver,
             #[cfg(feature = "pubsub")]
             subscribers.clone(),
-        )?;
+        );
 
         #[cfg(feature = "test-util")]
         let background_task_running = Arc::new(AtomicBool::new(true));

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -216,7 +216,7 @@ impl<A: CustomApi> Client<A> {
         #[cfg(feature = "pubsub")]
         let subscribers = SubscriberMap::default();
 
-        wasm_websocket_worker::reconnecting_client_loop(
+        wasm_websocket_worker::spawn_client(
             Arc::new(url),
             request_receiver,
             #[cfg(feature = "pubsub")]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -9,31 +9,43 @@ use std::{
     },
 };
 
+use async_lock::Mutex;
 use async_trait::async_trait;
 use flume::Sender;
 use pliantdb_core::{
     connection::{Database, ServerConnection},
     custom_api::CustomApi,
-    fabruic::Certificate,
     networking::{self, Payload, Request, Response, ServerRequest, ServerResponse},
     schema::{Schema, SchemaName, Schematic},
 };
-use tokio::{sync::Mutex, task::JoinHandle};
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::task::JoinHandle;
 use url::Url;
 
 pub use self::remote_database::RemoteDatabase;
+#[cfg(feature = "pubsub")]
+pub use self::remote_database::RemoteSubscriber;
 use crate::error::Error;
 
+#[cfg(not(target_arch = "wasm32"))]
+mod quic_worker;
 mod remote_database;
-#[cfg(feature = "websockets")]
-mod websocket_worker;
-mod worker;
+#[cfg(all(feature = "websockets", not(target_arch = "wasm32")))]
+mod tungstenite_worker;
+#[cfg(all(feature = "websockets", target_arch = "wasm32"))]
+mod wasm_websocket_worker;
 
 #[cfg(feature = "pubsub")]
 type SubscriberMap = Arc<Mutex<HashMap<u64, flume::Sender<Arc<Message>>>>>;
 
 #[cfg(feature = "pubsub")]
 use pliantdb_core::{circulate::Message, networking::DatabaseRequest};
+
+#[cfg(all(feature = "websockets", not(target_arch = "wasm32")))]
+pub type WebSocketError = tokio_tungstenite::tungstenite::Error;
+
+#[cfg(all(feature = "websockets", target_arch = "wasm32"))]
+pub type WebSocketError = wasm_websocket_worker::WebSocketError;
 
 /// Client for connecting to a `PliantDb` server.
 #[derive(Debug)]
@@ -56,6 +68,7 @@ type BackendPendingRequest<A: CustomApi> =
 #[derive(Debug)]
 pub struct Data<A: CustomApi> {
     request_sender: Sender<BackendPendingRequest<A>>,
+    #[cfg(not(target_arch = "wasm32"))]
     worker: CancellableHandle<Result<(), Error>>,
     schemas: Mutex<HashMap<TypeId, Arc<Schematic>>>,
     request_id: AtomicU32,
@@ -81,17 +94,13 @@ impl<A: CustomApi> Client<A> {
     /// to recover and reconnect, each component of the apps built can adopt a
     /// "retry-to-recover" design, or "abort-and-fail" depending on how critical
     /// the database is to operation.
-    pub async fn new(url: Url, certificate: Option<Certificate>) -> Result<Self, Error> {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn new_with_certificate(
+        url: Url,
+        certificate: Option<fabruic::Certificate>,
+    ) -> Result<Self, Error> {
         match url.scheme() {
-            "pliantdb" => {
-                let certificate = certificate.ok_or_else(|| {
-                    Error::InvalidUrl(String::from(
-                        "certificate must be provided with pliantdb:// urls",
-                    ))
-                })?;
-
-                Ok(Self::new_pliant_client(url, certificate))
-            }
+            "pliantdb" => Ok(Self::new_pliant_client(url, certificate)),
             #[cfg(feature = "websockets")]
             "wss" | "ws" => Self::new_websocket_client(url).await,
             other => {
@@ -100,12 +109,40 @@ impl<A: CustomApi> Client<A> {
         }
     }
 
-    fn new_pliant_client(url: Url, certificate: Certificate) -> Self {
+    /// Initialize a client connecting to `url` with `certificate` being used to
+    /// validate and encrypt the connection. This client can be shared by
+    /// cloning it. All requests are done asynchronously over the same
+    /// connection.
+    ///
+    /// If the client has an error connecting, the first request made will
+    /// present that error. If the client disconnects while processing requests,
+    /// all requests being processed will exit and return
+    /// [`Error::Disconnected`]. The client will automatically try reconnecting.
+    ///
+    /// The goal of this design of this reconnection strategy is to make it
+    /// easier to build resilliant apps. By allowing existing Client instances
+    /// to recover and reconnect, each component of the apps built can adopt a
+    /// "retry-to-recover" design, or "abort-and-fail" depending on how critical
+    /// the database is to operation.
+    pub async fn new(url: Url) -> Result<Self, Error> {
+        match url.scheme() {
+            #[cfg(not(target_arch = "wasm32"))]
+            "pliantdb" => Ok(Self::new_pliant_client(url, None)),
+            #[cfg(feature = "websockets")]
+            "wss" | "ws" => Self::new_websocket_client(url).await,
+            other => {
+                return Err(Error::InvalidUrl(format!("unsupported scheme {}", other)));
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn new_pliant_client(url: Url, certificate: Option<fabruic::Certificate>) -> Self {
         let (request_sender, request_receiver) = flume::unbounded();
 
         #[cfg(feature = "pubsub")]
         let subscribers = SubscriberMap::default();
-        let worker = tokio::task::spawn(worker::reconnecting_client_loop(
+        let worker = tokio::task::spawn(quic_worker::reconnecting_client_loop(
             url,
             certificate,
             request_receiver,
@@ -134,13 +171,14 @@ impl<A: CustomApi> Client<A> {
         }
     }
 
-    #[cfg(feature = "websockets")]
+    #[cfg(all(feature = "websockets", not(target_arch = "wasm32")))]
     async fn new_websocket_client(url: Url) -> Result<Self, Error> {
         let (request_sender, request_receiver) = flume::unbounded();
 
         #[cfg(feature = "pubsub")]
         let subscribers = SubscriberMap::default();
-        let worker = tokio::task::spawn(websocket_worker::reconnecting_client_loop(
+
+        let worker = tokio::task::spawn(tungstenite_worker::reconnecting_client_loop(
             url,
             request_receiver,
             #[cfg(feature = "pubsub")]
@@ -153,6 +191,45 @@ impl<A: CustomApi> Client<A> {
         let client = Self {
             data: Arc::new(Data {
                 request_sender,
+                #[cfg(not(target_arch = "wasm32"))]
+                worker: CancellableHandle {
+                    worker,
+                    #[cfg(feature = "test-util")]
+                    background_task_running: background_task_running.clone(),
+                },
+                schemas: Mutex::default(),
+                request_id: AtomicU32::default(),
+                #[cfg(feature = "pubsub")]
+                subscribers,
+                #[cfg(feature = "test-util")]
+                background_task_running,
+            }),
+        };
+
+        Ok(client)
+    }
+
+    #[cfg(all(feature = "websockets", target_arch = "wasm32"))]
+    async fn new_websocket_client(url: Url) -> Result<Self, Error> {
+        let (request_sender, request_receiver) = flume::unbounded();
+
+        #[cfg(feature = "pubsub")]
+        let subscribers = SubscriberMap::default();
+
+        wasm_websocket_worker::reconnecting_client_loop(
+            url,
+            request_receiver,
+            #[cfg(feature = "pubsub")]
+            subscribers.clone(),
+        )?;
+
+        #[cfg(feature = "test-util")]
+        let background_task_running = Arc::new(AtomicBool::new(true));
+
+        let client = Self {
+            data: Arc::new(Data {
+                request_sender,
+                #[cfg(not(target_arch = "wasm32"))]
                 worker: CancellableHandle {
                     worker,
                     #[cfg(feature = "test-util")]
@@ -312,8 +389,8 @@ impl ServerConnection for Client {
     }
 }
 
-type OutstandingRequestMap<O> = HashMap<u32, Sender<Result<Response<O>, Error>>>;
-type OutstandingRequestMapHandle<O> = Arc<Mutex<OutstandingRequestMap<O>>>;
+type OutstandingRequestMap<R, O> = HashMap<u32, PendingRequest<R, O>>;
+type OutstandingRequestMapHandle<R, O> = Arc<Mutex<OutstandingRequestMap<R, O>>>;
 
 #[derive(Debug)]
 pub struct PendingRequest<R, O> {
@@ -321,6 +398,7 @@ pub struct PendingRequest<R, O> {
     responder: Sender<Result<Response<O>, Error>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug)]
 struct CancellableHandle<T> {
     worker: JoinHandle<T>,
@@ -328,10 +406,50 @@ struct CancellableHandle<T> {
     background_task_running: Arc<AtomicBool>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> Drop for CancellableHandle<T> {
     fn drop(&mut self) {
         self.worker.abort();
         #[cfg(feature = "test-util")]
         self.background_task_running.store(false, Ordering::Release);
+    }
+}
+
+async fn process_response_payload<R: Send + Sync + 'static, O: Send + Sync + 'static>(
+    payload: Payload<Response<O>>,
+    outstanding_requests: &OutstandingRequestMapHandle<R, O>,
+    #[cfg(feature = "pubsub")] subscribers: &SubscriberMap,
+) {
+    if let Some(payload_id) = payload.id {
+        let request = {
+            let mut outstanding_requests = outstanding_requests.lock().await;
+            outstanding_requests
+                .remove(&payload_id)
+                .expect("missing responder")
+        };
+        drop(request.responder.send(Ok(payload.wrapped)));
+    } else {
+        #[cfg(feature = "pubsub")]
+        if let Response::Database(pliantdb_core::networking::DatabaseResponse::MessageReceived {
+            subscriber_id,
+            topic,
+            payload,
+        }) = payload.wrapped
+        {
+            let mut subscribers = subscribers.lock().await;
+            if let Some(sender) = subscribers.get(&subscriber_id) {
+                if sender
+                    .send(std::sync::Arc::new(pliantdb_core::circulate::Message {
+                        topic,
+                        payload,
+                    }))
+                    .is_err()
+                {
+                    subscribers.remove(&subscriber_id);
+                }
+            }
+        } else {
+            unreachable!("only MessageReceived is allowed to not have an id")
+        }
     }
 }

--- a/client/src/client/quic_worker.rs
+++ b/client/src/client/quic_worker.rs
@@ -85,7 +85,6 @@ async fn connect_and_process<
         );
     }
 
-    // TODO switch to select
     futures::try_join!(
         process_requests(outstanding_requests, request_receiver, payload_sender),
         async { request_processor.await.map_err(|_| Error::Disconnected)? }

--- a/client/src/client/tungstenite_worker.rs
+++ b/client/src/client/tungstenite_worker.rs
@@ -9,19 +9,17 @@ use tokio::net::TcpStream;
 use tokio_tungstenite::{tungstenite::Message, MaybeTlsStream, WebSocketStream};
 use url::Url;
 
+use super::PendingRequest;
 #[cfg(feature = "pubsub")]
 use crate::client::SubscriberMap;
-use crate::{
-    client::{OutstandingRequestMapHandle, PendingRequest},
-    Error,
-};
+use crate::{client::OutstandingRequestMapHandle, Error};
 
 pub async fn reconnecting_client_loop<
-    R: Send + Sync + Serialize + for<'de> Deserialize<'de>,
-    O: Serialize + for<'de> Deserialize<'de> + Send,
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
 >(
     url: Url,
-    mut request_receiver: Receiver<PendingRequest<R, O>>,
+    request_receiver: Receiver<PendingRequest<R, O>>,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) -> Result<(), Error> {
     while let Ok(request) = request_receiver.recv_async().await {
@@ -47,12 +45,12 @@ pub async fn reconnecting_client_loop<
             }
             outstanding_requests.insert(
                 request.request.id.expect("all requests must have ids"),
-                request.responder,
+                request,
             );
         }
 
         if let Err(err) = tokio::try_join!(
-            request_sender(&mut request_receiver, sender, outstanding_requests.clone()),
+            request_sender(&request_receiver, sender, outstanding_requests.clone()),
             response_processor(
                 receiver,
                 outstanding_requests,
@@ -68,33 +66,35 @@ pub async fn reconnecting_client_loop<
 }
 
 async fn request_sender<
-    R: Send + Sync + Serialize + for<'de> Deserialize<'de>,
-    O: Serialize + for<'de> Deserialize<'de> + Send,
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
 >(
-    request_receiver: &mut Receiver<PendingRequest<R, O>>,
+    request_receiver: &Receiver<PendingRequest<R, O>>,
     mut sender: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
-    outstanding_requests: OutstandingRequestMapHandle<O>,
+    outstanding_requests: OutstandingRequestMapHandle<R, O>,
 ) -> Result<(), Error> {
     while let Ok(pending) = request_receiver.recv_async().await {
-        {
-            let mut outstanding_requests = outstanding_requests.lock().await;
-            outstanding_requests.insert(
-                pending.request.id.expect("all requests must have ids"),
-                pending.responder,
-            );
-        }
+        let mut outstanding_requests = outstanding_requests.lock().await;
         sender
             .send(Message::Binary(bincode::serialize(&pending.request)?))
             .await?;
+
+        outstanding_requests.insert(
+            pending.request.id.expect("all requests must have ids"),
+            pending,
+        );
     }
 
     Err(Error::Disconnected)
 }
 
 #[allow(clippy::collapsible_else_if)] // not possible due to cfg statement
-async fn response_processor<O: for<'de> Deserialize<'de> + Send>(
+async fn response_processor<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Send + Sync + for<'de> Deserialize<'de> + 'static,
+>(
     mut receiver: SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
-    outstanding_requests: OutstandingRequestMapHandle<O>,
+    outstanding_requests: OutstandingRequestMapHandle<R, O>,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) -> Result<(), Error> {
     while let Some(message) = receiver.next().await {
@@ -103,40 +103,13 @@ async fn response_processor<O: for<'de> Deserialize<'de> + Send>(
             Message::Binary(response) => {
                 let payload = bincode::deserialize::<Payload<Response<O>>>(&response)?;
 
-                if let Some(payload_id) = payload.id {
-                    let responder = {
-                        let mut outstanding_requests = outstanding_requests.lock().await;
-                        outstanding_requests
-                            .remove(&payload_id)
-                            .expect("missing responder")
-                    };
-                    drop(responder.send(Ok(payload.wrapped)));
-                } else {
+                super::process_response_payload(
+                    payload,
+                    &outstanding_requests,
                     #[cfg(feature = "pubsub")]
-                    if let Response::Database(
-                        pliantdb_core::networking::DatabaseResponse::MessageReceived {
-                            subscriber_id,
-                            topic,
-                            payload,
-                        },
-                    ) = payload.wrapped
-                    {
-                        let mut subscribers = subscribers.lock().await;
-                        if let Some(sender) = subscribers.get(&subscriber_id) {
-                            if sender
-                                .send(std::sync::Arc::new(pliantdb_core::circulate::Message {
-                                    topic,
-                                    payload,
-                                }))
-                                .is_err()
-                            {
-                                subscribers.remove(&subscriber_id);
-                            }
-                        }
-                    } else {
-                        unreachable!("only MessageReceived is allowed to not have an id")
-                    }
-                }
+                    &subscribers,
+                )
+                .await;
             }
             other => {
                 println!("Unexpected websocket message: {:?}", other);

--- a/client/src/client/wasm_websocket_worker.rs
+++ b/client/src/client/wasm_websocket_worker.rs
@@ -1,9 +1,14 @@
+use std::sync::{
+    atomic::{AtomicI32, Ordering},
+    Arc,
+};
+
 use flume::Receiver;
 use pliantdb_core::networking::{Payload, Response};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
-use web_sys::{MessageEvent, WebSocket};
+use web_sys::{CloseEvent, ErrorEvent, MessageEvent, WebSocket};
 
 #[cfg(feature = "pubsub")]
 use crate::client::SubscriberMap;
@@ -20,25 +25,194 @@ pub fn reconnecting_client_loop<
     request_receiver: Receiver<PendingRequest<R, O>>,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) -> Result<(), Error> {
+    spawn_reconnecting_websocket(
+        Arc::new(url),
+        request_receiver,
+        Arc::default(),
+        #[cfg(feature = "pubsub")]
+        subscribers,
+    )
+}
+
+fn respawn_reconnecting_websocket<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    url: Arc<Url>,
+    request_receiver: Receiver<PendingRequest<R, O>>,
+    reconnect_delay: Arc<AtomicI32>,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) {
+    let delay_in_ms = reconnect_delay
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |existing_delay| {
+            Some(existing_delay.clamp(50, 30000) * 2)
+        })
+        .unwrap();
+    log::info!("Respawning with {} delay", delay_in_ms);
+    let window = web_sys::window().expect("no window");
+    window
+        .set_timeout_with_callback_and_timeout_and_arguments_0(
+            Closure::once_into_js(move || {
+                spawn_reconnecting_websocket(url, request_receiver, reconnect_delay, subscribers)
+                    .unwrap()
+            })
+            .as_ref()
+            .unchecked_ref(),
+            delay_in_ms,
+        )
+        .unwrap();
+}
+
+fn spawn_reconnecting_websocket<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    url: Arc<Url>,
+    request_receiver: Receiver<PendingRequest<R, O>>,
+    reconnect_delay: Arc<AtomicI32>,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) -> Result<(), Error> {
     // In wasm we're not going to have a real loop. We're going create a websocket and store it in JS. This will allow us to get around Send/Sync issues since each access of the websocket can pull it from js.
-    let ws = WebSocket::new(&url.to_string()).map_err(WebSocketError::from)?;
+    log::info!("spawning");
+    let ws = match WebSocket::new(&url.to_string()) {
+        Ok(ws) => ws,
+        Err(err) => {
+            log::info!("Error connecting");
+            respawn_reconnecting_websocket(
+                url,
+                request_receiver,
+                reconnect_delay,
+                #[cfg(feature = "pubsub")]
+                subscribers,
+            );
+            return Err(Error::from(WebSocketError::from(err)));
+        }
+    };
+    let onerror_callback = on_error_callback(ws.clone());
+    ws.set_onerror(Some(onerror_callback.as_ref().unchecked_ref()));
     ws.set_binary_type(web_sys::BinaryType::Arraybuffer);
     let outstanding_requests = OutstandingRequestMapHandle::default();
-    #[cfg(feature = "pubsub")]
-    let closure_subscribers = subscribers.clone();
-    let closure_requests = outstanding_requests.clone();
-    let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
-        log::info!("received response");
+    let onmessage_callback = on_message_callback(
+        outstanding_requests.clone(),
+        #[cfg(feature = "pubsub")]
+        subscribers.clone(),
+    );
+
+    let onopen_callback = on_open_callback(
+        url.clone(),
+        request_receiver.clone(),
+        reconnect_delay.clone(),
+        outstanding_requests.clone(),
+        ws.clone(),
+        #[cfg(feature = "pubsub")]
+        subscribers.clone(),
+    );
+
+    let onclose_callback = on_close_callback(
+        url.clone(),
+        request_receiver.clone(),
+        reconnect_delay.clone(),
+        ws.clone(),
+        #[cfg(feature = "pubsub")]
+        subscribers.clone(),
+    );
+
+    ws.set_onopen(Some(onopen_callback.as_ref().unchecked_ref()));
+    ws.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
+    ws.set_onclose(Some(onclose_callback.as_ref().unchecked_ref()));
+
+    let window = web_sys::window().unwrap();
+    js_sys::Reflect::set(&window, &JsValue::symbol(Some("pliantdb_websocket")), &ws).unwrap();
+
+    Ok(())
+}
+
+fn on_open_callback<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    url: Arc<Url>,
+    request_receiver: Receiver<PendingRequest<R, O>>,
+    reconnect_delay: Arc<AtomicI32>,
+    requests: OutstandingRequestMapHandle<R, O>,
+    ws: WebSocket,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) -> JsValue {
+    Closure::wrap(Box::new(move |_| {
+        log::info!("Opened!");
+        // Upon success connecting, reset the reconnect delay.
+        reconnect_delay.store(0, Ordering::SeqCst);
+
+        let closure_ws = ws.clone();
+        let request_receiver = request_receiver.clone();
+        let requests = requests.clone();
+        let reconnect_delay = reconnect_delay.clone();
+        let url = url.clone();
+        #[cfg(feature = "pubsub")]
+        let subscribers = subscribers.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            while let Ok(pending) = request_receiver.recv_async().await {
+                let mut outstanding_requests = requests.lock().await;
+                let bytes = match bincode::serialize(&pending.request) {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
+                        drop(pending.responder.send(Err(Error::from(err))));
+                        continue;
+                    }
+                };
+                match closure_ws.send_with_u8_array(&bytes) {
+                    Ok(_) => {
+                        outstanding_requests.insert(
+                            pending.request.id.expect("all requests must have ids"),
+                            pending,
+                        );
+                    }
+                    Err(err) => {
+                        drop(
+                            pending
+                                .responder
+                                .send(Err(Error::from(WebSocketError::from(err)))),
+                        );
+                        break;
+                    }
+                }
+            }
+
+            drop(closure_ws.close());
+            respawn_reconnecting_websocket(
+                url,
+                request_receiver,
+                reconnect_delay,
+                #[cfg(feature = "pubsub")]
+                subscribers,
+            );
+        });
+    }) as Box<dyn FnMut(JsValue)>)
+    .into_js_value()
+}
+
+fn on_message_callback<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    outstanding_requests: OutstandingRequestMapHandle<R, O>,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) -> JsValue {
+    Closure::wrap(Box::new(move |e: MessageEvent| {
         // Handle difference Text/Binary,...
         if let Ok(abuf) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
             let array = js_sys::Uint8Array::new(&abuf);
-            let payload = bincode::deserialize::<Payload<Response<O>>>(&array.to_vec())
-                .expect("error parsing payload"); // TODO remove expect
-            log::info!("received payload: {:?}", payload.id);
+            let payload = match bincode::deserialize::<Payload<Response<O>>>(&array.to_vec()) {
+                Ok(payload) => payload,
+                Err(err) => {
+                    log::error!("error deserializing response: {:?}", err);
+                    return;
+                }
+            };
 
-            let outstanding_requests = closure_requests.clone();
+            let outstanding_requests = outstanding_requests.clone();
             #[cfg(feature = "pubsub")]
-            let subscribers = closure_subscribers.clone();
+            let subscribers = subscribers.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 super::process_response_payload::<R, O>(
                     payload,
@@ -49,42 +223,46 @@ pub fn reconnecting_client_loop<
                 .await;
             });
         } else {
-            // console_log!("Unexpected websocket message: {:?}", e.data());
+            log::warn!("Unexpected WebSocket message received: {:?}", e.data());
         }
     }) as Box<dyn FnMut(MessageEvent)>)
-    .into_js_value();
+    .into_js_value()
+}
 
-    let closure_ws = ws.clone();
-    let closure_requests = outstanding_requests.clone();
-    let onopen_callback = Closure::wrap(Box::new(move |_| {
-        log::info!("connected");
-        let closure_ws = closure_ws.clone();
-        let request_receiver = request_receiver.clone();
-        let closure_requests = closure_requests.clone();
-        wasm_bindgen_futures::spawn_local(async move {
-            while let Ok(pending) = request_receiver.recv_async().await {
-                log::info!("received request");
-                let mut outstanding_requests = closure_requests.lock().await;
-                closure_ws
-                    .send_with_u8_array(&bincode::serialize(&pending.request).unwrap())
-                    .unwrap(); // TODO remove unwrap
+fn on_error_callback(ws: WebSocket) -> JsValue {
+    Closure::once_into_js(move |e: ErrorEvent| {
+        log::error!(
+            "websocket error '{}'",
+            e.error().as_string().unwrap_or_default()
+        );
+        ws.set_onerror(None);
 
-                outstanding_requests.insert(
-                    pending.request.id.expect("all requests must have ids"),
-                    pending,
-                );
-            }
-        });
-    }) as Box<dyn FnMut(JsValue)>)
-    .into_js_value();
+        ws.close().unwrap();
+    })
+}
 
-    ws.set_onopen(Some(onopen_callback.as_ref().unchecked_ref()));
-    ws.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
+fn on_close_callback<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    url: Arc<Url>,
+    request_receiver: Receiver<PendingRequest<R, O>>,
+    reconnect_delay: Arc<AtomicI32>,
+    ws: WebSocket,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) -> JsValue {
+    Closure::once_into_js(move |c: CloseEvent| {
+        log::error!("websocket closed ({}): {:?}", c.code(), c.reason());
+        ws.set_onclose(None);
 
-    let window = web_sys::window().unwrap();
-    js_sys::Reflect::set(&window, &JsValue::symbol(Some("pliantdb_websocket")), &ws).unwrap();
-
-    Ok(())
+        respawn_reconnecting_websocket(
+            url,
+            request_receiver,
+            reconnect_delay,
+            #[cfg(feature = "pubsub")]
+            subscribers,
+        );
+    })
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/client/src/client/wasm_websocket_worker.rs
+++ b/client/src/client/wasm_websocket_worker.rs
@@ -1,7 +1,4 @@
-use std::sync::{
-    atomic::{AtomicI32, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 
 use flume::Receiver;
 use pliantdb_core::networking::{Payload, Response};
@@ -21,71 +18,53 @@ pub fn reconnecting_client_loop<
     R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
 >(
-    url: Url,
-    request_receiver: Receiver<PendingRequest<R, O>>,
-    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
-) -> Result<(), Error> {
-    spawn_reconnecting_websocket(
-        Arc::new(url),
-        request_receiver,
-        Arc::default(),
-        #[cfg(feature = "pubsub")]
-        subscribers,
-    )
-}
-
-fn respawn_reconnecting_websocket<
-    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
-    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
->(
     url: Arc<Url>,
     request_receiver: Receiver<PendingRequest<R, O>>,
-    reconnect_delay: Arc<AtomicI32>,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) {
-    let delay_in_ms = reconnect_delay
-        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |existing_delay| {
-            Some(existing_delay.clamp(50, 30000) * 2)
-        })
-        .unwrap();
-    log::info!("Respawning with {} delay", delay_in_ms);
-    let window = web_sys::window().expect("no window");
-    window
-        .set_timeout_with_callback_and_timeout_and_arguments_0(
-            Closure::once_into_js(move || {
-                spawn_reconnecting_websocket(url, request_receiver, reconnect_delay, subscribers)
-                    .unwrap()
-            })
-            .as_ref()
-            .unchecked_ref(),
-            delay_in_ms,
-        )
-        .unwrap();
+    wasm_bindgen_futures::spawn_local(spawn_reconnecting_websocket(
+        url,
+        request_receiver,
+        #[cfg(feature = "pubsub")]
+        subscribers,
+    ));
 }
 
-fn spawn_reconnecting_websocket<
+async fn spawn_reconnecting_websocket<
     R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
     O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
 >(
     url: Arc<Url>,
     request_receiver: Receiver<PendingRequest<R, O>>,
-    reconnect_delay: Arc<AtomicI32>,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
-) -> Result<(), Error> {
-    // In wasm we're not going to have a real loop. We're going create a websocket and store it in JS. This will allow us to get around Send/Sync issues since each access of the websocket can pull it from js.
+) {
+    // Receive the next/initial request when we are reconnecting.
+    let initial_request = match request_receiver.recv_async().await {
+        Ok(r) => r,
+        Err(_) => return,
+    };
+    // In wasm we're not going to have a real loop. We're going create a
+    // websocket and store it in JS. This will allow us to get around Send/Sync
+    // issues since each access of the websocket can pull it from js.
     log::info!("spawning");
     let ws = match WebSocket::new(&url.to_string()) {
         Ok(ws) => ws,
         Err(err) => {
+            drop(
+                initial_request
+                    .responder
+                    .send(Err(Error::from(WebSocketError::from(err)))),
+            );
             log::info!("Error connecting");
-            respawn_reconnecting_websocket(
+            reconnecting_client_loop(
                 url,
                 request_receiver,
-                reconnect_delay,
                 #[cfg(feature = "pubsub")]
                 subscribers,
             );
-            return Err(Error::from(WebSocketError::from(err)));
+            // Since we sent the error to the responder and are attempting to
+            // reconnect we should treat this call as successful.
+            return;
         }
     };
     let onerror_callback = on_error_callback(ws.clone());
@@ -101,7 +80,7 @@ fn spawn_reconnecting_websocket<
     let onopen_callback = on_open_callback(
         url.clone(),
         request_receiver.clone(),
-        reconnect_delay.clone(),
+        initial_request,
         outstanding_requests.clone(),
         ws.clone(),
         #[cfg(feature = "pubsub")]
@@ -111,7 +90,6 @@ fn spawn_reconnecting_websocket<
     let onclose_callback = on_close_callback(
         url.clone(),
         request_receiver.clone(),
-        reconnect_delay.clone(),
         ws.clone(),
         #[cfg(feature = "pubsub")]
         subscribers.clone(),
@@ -123,8 +101,6 @@ fn spawn_reconnecting_websocket<
 
     let window = web_sys::window().unwrap();
     js_sys::Reflect::set(&window, &JsValue::symbol(Some("pliantdb_websocket")), &ws).unwrap();
-
-    Ok(())
 }
 
 fn on_open_callback<
@@ -133,62 +109,70 @@ fn on_open_callback<
 >(
     url: Arc<Url>,
     request_receiver: Receiver<PendingRequest<R, O>>,
-    reconnect_delay: Arc<AtomicI32>,
+    initial_request: PendingRequest<R, O>,
     requests: OutstandingRequestMapHandle<R, O>,
     ws: WebSocket,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) -> JsValue {
-    Closure::wrap(Box::new(move |_| {
+    Closure::once_into_js(move || {
         log::info!("Opened!");
-        // Upon success connecting, reset the reconnect delay.
-        reconnect_delay.store(0, Ordering::SeqCst);
-
-        let closure_ws = ws.clone();
-        let request_receiver = request_receiver.clone();
-        let requests = requests.clone();
-        let reconnect_delay = reconnect_delay.clone();
-        let url = url.clone();
-        #[cfg(feature = "pubsub")]
-        let subscribers = subscribers.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            while let Ok(pending) = request_receiver.recv_async().await {
-                let mut outstanding_requests = requests.lock().await;
-                let bytes = match bincode::serialize(&pending.request) {
-                    Ok(bytes) => bytes,
-                    Err(err) => {
-                        drop(pending.responder.send(Err(Error::from(err))));
-                        continue;
-                    }
-                };
-                match closure_ws.send_with_u8_array(&bytes) {
-                    Ok(_) => {
-                        outstanding_requests.insert(
-                            pending.request.id.expect("all requests must have ids"),
-                            pending,
-                        );
-                    }
-                    Err(err) => {
-                        drop(
-                            pending
-                                .responder
-                                .send(Err(Error::from(WebSocketError::from(err)))),
-                        );
+            if send_request(&ws, initial_request, &requests).await {
+                while let Ok(pending) = request_receiver.recv_async().await {
+                    if !send_request(&ws, pending, &requests).await {
                         break;
                     }
                 }
             }
 
-            drop(closure_ws.close());
-            respawn_reconnecting_websocket(
+            drop(ws.close());
+            drop(ws);
+            reconnecting_client_loop(
                 url,
                 request_receiver,
-                reconnect_delay,
                 #[cfg(feature = "pubsub")]
                 subscribers,
             );
         });
-    }) as Box<dyn FnMut(JsValue)>)
-    .into_js_value()
+    })
+}
+
+#[must_use]
+async fn send_request<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    ws: &WebSocket,
+    pending: PendingRequest<R, O>,
+    requests: &OutstandingRequestMapHandle<R, O>,
+) -> bool {
+    let mut outstanding_requests = requests.lock().await;
+    let bytes = match bincode::serialize(&pending.request) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            drop(pending.responder.send(Err(Error::from(err))));
+            // Despite not sending, this error was handled, so we report
+            // success.
+            return true;
+        }
+    };
+    match ws.send_with_u8_array(&bytes) {
+        Ok(_) => {
+            outstanding_requests.insert(
+                pending.request.id.expect("all requests must have ids"),
+                pending,
+            );
+            true
+        }
+        Err(err) => {
+            drop(
+                pending
+                    .responder
+                    .send(Err(Error::from(WebSocketError::from(err)))),
+            );
+            false
+        }
+    }
 }
 
 fn on_message_callback<
@@ -247,7 +231,6 @@ fn on_close_callback<
 >(
     url: Arc<Url>,
     request_receiver: Receiver<PendingRequest<R, O>>,
-    reconnect_delay: Arc<AtomicI32>,
     ws: WebSocket,
     #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
 ) -> JsValue {
@@ -255,10 +238,9 @@ fn on_close_callback<
         log::error!("websocket closed ({}): {:?}", c.code(), c.reason());
         ws.set_onclose(None);
 
-        respawn_reconnecting_websocket(
+        reconnecting_client_loop(
             url,
             request_receiver,
-            reconnect_delay,
             #[cfg(feature = "pubsub")]
             subscribers,
         );

--- a/client/src/client/wasm_websocket_worker.rs
+++ b/client/src/client/wasm_websocket_worker.rs
@@ -1,0 +1,108 @@
+use flume::Receiver;
+use pliantdb_core::networking::{Payload, Response};
+use serde::{Deserialize, Serialize};
+use url::Url;
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+use web_sys::{MessageEvent, WebSocket};
+
+#[cfg(feature = "pubsub")]
+use crate::client::SubscriberMap;
+use crate::{
+    client::{OutstandingRequestMapHandle, PendingRequest},
+    Error,
+};
+
+pub fn reconnecting_client_loop<
+    R: Send + Sync + Serialize + for<'de> Deserialize<'de> + 'static,
+    O: Serialize + for<'de> Deserialize<'de> + Send + Sync + 'static,
+>(
+    url: Url,
+    request_receiver: Receiver<PendingRequest<R, O>>,
+    #[cfg(feature = "pubsub")] subscribers: SubscriberMap,
+) -> Result<(), Error> {
+    // In wasm we're not going to have a real loop. We're going create a websocket and store it in JS. This will allow us to get around Send/Sync issues since each access of the websocket can pull it from js.
+    let ws = WebSocket::new(&url.to_string()).map_err(WebSocketError::from)?;
+    ws.set_binary_type(web_sys::BinaryType::Arraybuffer);
+    let outstanding_requests = OutstandingRequestMapHandle::default();
+    #[cfg(feature = "pubsub")]
+    let closure_subscribers = subscribers.clone();
+    let closure_requests = outstanding_requests.clone();
+    let onmessage_callback = Closure::wrap(Box::new(move |e: MessageEvent| {
+        log::info!("received response");
+        // Handle difference Text/Binary,...
+        if let Ok(abuf) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
+            let array = js_sys::Uint8Array::new(&abuf);
+            let payload = bincode::deserialize::<Payload<Response<O>>>(&array.to_vec())
+                .expect("error parsing payload"); // TODO remove expect
+            log::info!("received payload: {:?}", payload.id);
+
+            let outstanding_requests = closure_requests.clone();
+            #[cfg(feature = "pubsub")]
+            let subscribers = closure_subscribers.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                super::process_response_payload::<R, O>(
+                    payload,
+                    &outstanding_requests,
+                    #[cfg(feature = "pubsub")]
+                    &subscribers,
+                )
+                .await;
+            });
+        } else {
+            // console_log!("Unexpected websocket message: {:?}", e.data());
+        }
+    }) as Box<dyn FnMut(MessageEvent)>)
+    .into_js_value();
+
+    let closure_ws = ws.clone();
+    let closure_requests = outstanding_requests.clone();
+    let onopen_callback = Closure::wrap(Box::new(move |_| {
+        log::info!("connected");
+        let closure_ws = closure_ws.clone();
+        let request_receiver = request_receiver.clone();
+        let closure_requests = closure_requests.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            while let Ok(pending) = request_receiver.recv_async().await {
+                log::info!("received request");
+                let mut outstanding_requests = closure_requests.lock().await;
+                closure_ws
+                    .send_with_u8_array(&bincode::serialize(&pending.request).unwrap())
+                    .unwrap(); // TODO remove unwrap
+
+                outstanding_requests.insert(
+                    pending.request.id.expect("all requests must have ids"),
+                    pending,
+                );
+            }
+        });
+    }) as Box<dyn FnMut(JsValue)>)
+    .into_js_value();
+
+    ws.set_onopen(Some(onopen_callback.as_ref().unchecked_ref()));
+    ws.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
+
+    let window = web_sys::window().unwrap();
+    js_sys::Reflect::set(&window, &JsValue::symbol(Some("pliantdb_websocket")), &ws).unwrap();
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("WebSocket error: {0}")]
+pub struct WebSocketError(String);
+
+impl From<JsValue> for WebSocketError {
+    fn from(value: JsValue) -> Self {
+        Self(if let Some(value) = value.as_string() {
+            value
+        } else if let Some(value) = value.as_f64() {
+            value.to_string()
+        } else if let Some(value) = value.as_bool() {
+            value.to_string()
+        } else if value.is_null() {
+            String::from("(null)")
+        } else {
+            String::from("(undefined)")
+        })
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -21,6 +21,8 @@ pub use url;
 mod client;
 mod error;
 
+#[cfg(feature = "pubsub")]
+pub use self::client::RemoteSubscriber;
 pub use self::{
     client::{Client, RemoteDatabase},
     error::Error,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,9 +14,8 @@ homepage = "https://pliantdb.dev/"
 [features]
 default = []
 test-util = ["futures", "tokio", "networking", "websockets"]
-networking = ["fabruic"]
+networking = []
 websockets = []
-trusted-dns = ["fabruic/trust-dns"]
 pubsub = ["circulate"]
 keyvalue = ["futures"]
 actionable-traits = []
@@ -33,7 +32,6 @@ anyhow = "1"
 sha2 = "0.9"
 futures = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["time"], optional = true }
-fabruic = { version = "0.0.1-dev.2", optional = true, features = ["dangerous"] }
 num-traits = "0.2"
 actionable = "0.1.0-dev.2"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,24 +21,24 @@ keyvalue = ["futures"]
 actionable-traits = []
 
 [dependencies]
-pliantdb-macros = { path = "../macros" }
-circulate = { path = "../circulate", version = "0.1.0-dev.1", optional = true }
-serde = { version = "1", features = ["derive"] }
+pliantdb-macros = { path="../macros" }
+circulate = { path="../circulate", version="0.1.0-dev.1", optional=true }
+serde = { version="1", features=["derive"] }
 serde_cbor = "0.11"
 async-trait = "0.1"
-uuid = { version = "0.8", features = ["v4", "serde"], optional = true }
+uuid = { version="0.8", features=["v4", "serde"], optional=true }
 thiserror = "1"
 anyhow = "1"
 sha2 = "0.9"
-futures = { version = "0.3", optional = true }
-tokio = { version = "1", features = ["time"], optional = true }
+futures = { version="0.3", optional=true }
+tokio = { version="1", features=["time"], optional=true }
 num-traits = "0.2"
-actionable = "0.1.0-dev.2"
+actionable = "0.1.0-dev.3"
 
 [dev-dependencies]
 hex-literal = "0.3"
-tokio = { version = "1", features = ["full"] }
-futures = { version = "0.3" }
+tokio = { version="1", features=["full"] }
+futures = { version="0.3" }
 num-derive = "0.3"
 
 [package.metadata.docs.rs]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -38,8 +38,6 @@ pub mod kv;
 pub mod custom_api;
 
 #[cfg(feature = "networking")]
-pub use fabruic;
-#[cfg(feature = "networking")]
 /// Types for implementing the `PliantDb` network protocol.
 pub mod networking;
 

--- a/core/src/networking.rs
+++ b/core/src/networking.rs
@@ -1,4 +1,3 @@
-pub use fabruic;
 use schema::SchemaName;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -506,7 +506,7 @@ pub async fn store_retrieve_update_delete_tests<C: Connection>(db: &C) -> anyhow
             Basic::collection_name()?
         );
         assert_eq!(transaction.changed_documents[0].id, header.id);
-        assert_eq!(transaction.changed_documents[0].deleted, false);
+        assert!(!transaction.changed_documents[0].deleted);
     }
 
     db.delete::<Basic>(&doc).await?;
@@ -522,7 +522,7 @@ pub async fn store_retrieve_update_delete_tests<C: Connection>(db: &C) -> anyhow
         Basic::collection_name()?
     );
     assert_eq!(transaction.changed_documents[0].id, header.id);
-    assert_eq!(transaction.changed_documents[0].deleted, true);
+    assert!(transaction.changed_documents[0].deleted);
 
     Ok(())
 }

--- a/core/src/test_util.rs
+++ b/core/src/test_util.rs
@@ -1193,7 +1193,7 @@ pub async fn basic_server_connection_tests<C: ServerConnection>(
     ));
 
     assert!(matches!(
-        dbg!(server.create_database::<Basic>("|invalidname").await),
+        server.create_database::<Basic>("|invalidname").await,
         Err(Error::InvalidDatabaseName(_))
     ));
 

--- a/local/src/backup.rs
+++ b/local/src/backup.rs
@@ -345,7 +345,7 @@ async fn write_documents(receiver: Receiver<BackupEntry>, backup: PathBuf) -> an
     Ok(())
 }
 
-#[allow(clippy::clippy::needless_pass_by_value)] // it's not needless, it's to avoid a borrow that would need to span a 'static lifetime
+#[allow(clippy::needless_pass_by_value)] // it's not needless, it's to avoid a borrow that would need to span a 'static lifetime
 fn restore_documents(receiver: Receiver<BackupEntry>, storage: Storage) -> anyhow::Result<()> {
     while let Ok(entry) = receiver.recv() {
         match entry {

--- a/local/src/storage/kv.rs
+++ b/local/src/storage/kv.rs
@@ -37,7 +37,7 @@ pub fn expiration_thread(
             let remaining_time = *timeout - now;
             let received_update = if let Some(remaining_time) = remaining_time {
                 // Allow flume to receive updates for the remaining time.
-                match updates.recv_timeout(dbg!(remaining_time)) {
+                match updates.recv_timeout(remaining_time) {
                     Ok(update) => Ok(update),
                     Err(flume::RecvTimeoutError::Timeout) => Err(()),
                     Err(flume::RecvTimeoutError::Disconnected) => break,
@@ -348,13 +348,13 @@ impl Job for ExpirationLoader {
         });
 
         while let Ok((tree, key, expiration)) = receiver.recv_async().await {
-            self.storage.update_key_expiration(dbg!(ExpirationUpdate {
+            self.storage.update_key_expiration(ExpirationUpdate {
                 tree_key: TreeKey {
                     tree: String::from_utf8(tree)?,
                     key: String::from_utf8(key)?,
                 },
                 expiration,
-            }));
+            });
         }
 
         Ok(())

--- a/local/src/views/integrity_scanner.rs
+++ b/local/src/views/integrity_scanner.rs
@@ -77,7 +77,7 @@ where
 
                 document_ids
                     .difference(&stored_document_ids)
-                    .cloned()
+                    .copied()
                     .collect::<HashSet<_>>()
             } else {
                 // The view isn't the current version, queue up all documents.

--- a/local/src/views/mapper.rs
+++ b/local/src/views/mapper.rs
@@ -45,7 +45,7 @@ where
 {
     type Output = u64;
 
-    #[allow(clippy::clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines)]
     async fn execute(&mut self) -> anyhow::Result<Self::Output> {
         let documents = self
             .storage

--- a/pliantdb/Cargo.toml
+++ b/pliantdb/Cargo.toml
@@ -116,6 +116,7 @@ url = "2.2"
 once_cell = "1"
 flume = "0.10"
 actionable = "0.1.0-dev.2"
+fabruic = { version = "0.0.1-dev.2" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pliantdb/Cargo.toml
+++ b/pliantdb/Cargo.toml
@@ -96,27 +96,27 @@ client-keyvalue = ["pliantdb-client/keyvalue", "pliantdb-core/keyvalue"]
 local-keyvalue = ["pliantdb-local/keyvalue", "pliantdb-core/keyvalue"]
 
 [dependencies]
-pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false }
-pliantdb-local = { path = "../local", version = "0.1.0-dev.3", default-features = false, optional = true }
-pliantdb-client = { path = "../client", version = "0.1.0-dev.3", default-features = false, optional = true }
-pliantdb-server = { path = "../server", version = "0.1.0-dev.3", default-features = false, optional = true }
+pliantdb-core = { path="../core", version="0.1.0-dev.3", default-features=false }
+pliantdb-local = { path="../local", version="0.1.0-dev.3", default-features=false, optional=true }
+pliantdb-client = { path="../client", version="0.1.0-dev.3", default-features=false, optional=true }
+pliantdb-server = { path="../server", version="0.1.0-dev.3", default-features=false, optional=true }
 
-tokio = { version = "1", features = ["full"], optional = true }
-structopt = { version = "0.3", optional = true }
-anyhow = { version = "1", optional = true }
+tokio = { version="1", features=["full"], optional=true }
+structopt = { version="0.3", optional=true }
+anyhow = { version="1", optional=true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
+tokio = { version="1", features=["full"] }
+serde = { version="1", features=["derive"] }
 anyhow = "1"
-pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false, features = ["test-util"] }
+pliantdb-core = { path="../core", version="0.1.0-dev.3", default-features=false, features=["test-util"] }
 futures = "0.3"
 rand = "0.8"
 url = "2.2"
 once_cell = "1"
 flume = "0.10"
-actionable = "0.1.0-dev.2"
-fabruic = { version = "0.0.1-dev.2" }
+actionable = "0.1.0-dev.3"
+fabruic = { version="0.0.1-dev.2" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pliantdb/examples/server.rs
+++ b/pliantdb/examples/server.rs
@@ -65,7 +65,7 @@ async fn main() -> anyhow::Result<()> {
     {
         // To connect over websockets, use the websocket scheme.
         tasks.push(do_some_database_work(
-            Client::<()>::new(Url::parse("ws://localhost:8080")?, None)
+            Client::<()>::new(Url::parse("ws://localhost:8080")?)
                 .await?
                 .database::<Shape>("my-database")
                 .await?,
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 
     // To connect over QUIC, use the pliantdb scheme.
     tasks.push(do_some_database_work(
-        Client::<()>::new(
+        Client::<()>::new_with_certificate(
             Url::parse("pliantdb://localhost")?,
             Some(certificate),
         )

--- a/pliantdb/tests/core-suite.rs
+++ b/pliantdb/tests/core-suite.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
+use fabruic::Certificate;
 use once_cell::sync::Lazy;
 use pliantdb::{
     client::{Client, RemoteDatabase},
     core::{
         connection::ServerConnection,
-        fabruic::Certificate,
         test_util::{BasicSchema, HarnessTest, TestDirectory},
     },
     server::test_util::{initialize_basic_server, BASIC_SERVER_NAME},
@@ -67,7 +67,7 @@ mod websockets {
         pub async fn new(test: HarnessTest) -> anyhow::Result<Self> {
             initialize_shared_server().await;
             let url = Url::parse("ws://localhost:6001")?;
-            let client = Client::new(url, None).await?;
+            let client = Client::new(url).await?;
 
             let dbname = format!("websockets-{}", test);
             client.create_database::<BasicSchema>(&dbname).await?;
@@ -116,7 +116,7 @@ mod pliant {
                 "pliantdb://localhost:6000?server={}",
                 BASIC_SERVER_NAME
             ))?;
-            let client = Client::new(url, Some(certificate)).await?;
+            let client = Client::new_with_certificate(url, Some(certificate)).await?;
 
             let dbname = format!("pliant-{}", test);
             client.create_database::<BasicSchema>(&dbname).await?;

--- a/pliantdb/tests/custom-api.rs
+++ b/pliantdb/tests/custom-api.rs
@@ -57,9 +57,11 @@ async fn custom_api() -> anyhow::Result<()> {
     server.register_schema::<Basic>().await?;
     tokio::spawn(async move { server.listen_on(12346).await });
 
-    let client =
-        Client::<CustomBackend>::new(Url::parse("pliantdb://localhost:12346")?, Some(certificate))
-            .await?;
+    let client = Client::<CustomBackend>::new_with_certificate(
+        Url::parse("pliantdb://localhost:12346")?,
+        Some(certificate),
+    )
+    .await?;
 
     let CustomResponse::Pong = client.send_api_request(CustomRequest::Ping).await?;
 

--- a/pliantdb/tests/simultaneous-connections.rs
+++ b/pliantdb/tests/simultaneous-connections.rs
@@ -28,7 +28,7 @@ async fn simultaneous_connections() -> anyhow::Result<()> {
     server.register_schema::<Basic>().await?;
     tokio::spawn(async move { server.listen_on(12345).await });
 
-    let client = Client::new(
+    let client = Client::new_with_certificate(
         Url::parse("pliantdb://localhost:12345?server=test")?,
         Some(certificate),
     )

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,30 +21,30 @@ pubsub = ["pliantdb-core/pubsub", "pliantdb-local/pubsub"]
 keyvalue = ["pliantdb-core/keyvalue", "pliantdb-local/keyvalue"]
 
 [dependencies]
-pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false, features = [
+pliantdb-core = { path="../core", version="0.1.0-dev.3", default-features=false, features=[
     "networking",
     "actionable-traits",
 ] }
-pliantdb-local = { path = "../local", version = "0.1.0-dev.3", default-features = false, features = ["internal-apis"] }
-pliantdb-jobs = { path = "../jobs", version = "0.1.0-dev.3" }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
+pliantdb-local = { path="../local", version="0.1.0-dev.3", default-features=false, features=["internal-apis"] }
+pliantdb-jobs = { path="../jobs", version="0.1.0-dev.3" }
+serde = { version="1", features=["derive"] }
+tokio = { version="1", features=["full"] }
 thiserror = "1"
 async-trait = "0.1"
-structopt = { version = "0.3", optional = true }
+structopt = { version="0.3", optional=true }
 anyhow = "1"
 futures = "0.3"
 flume = "0.10"
 itertools = "0.10"
-tokio-tungstenite = { version = "0.14", optional = true }
-bincode = { version = "1", optional = true }
+tokio-tungstenite = { version="0.14", optional=true }
+bincode = { version="1", optional=true }
 cfg-if = "1"
-actionable = "0.1.0-dev.2"
+actionable = "0.1.0-dev.3"
 serde_cbor = "0.11"
-fabruic = { version = "0.0.1-dev.2", features = ["dangerous"] }
+fabruic = { version="0.0.1-dev.2", features=["dangerous"] }
 
 [dev-dependencies]
-pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false, features = ["test-util"] }
+pliantdb-core = { path="../core", version="0.1.0-dev.3", default-features=false, features=["test-util"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,6 +41,7 @@ bincode = { version = "1", optional = true }
 cfg-if = "1"
 actionable = "0.1.0-dev.2"
 serde_cbor = "0.11"
+fabruic = { version = "0.0.1-dev.2", features = ["dangerous"] }
 
 [dev-dependencies]
 pliantdb-core = { path = "../core", version = "0.1.0-dev.3", default-features = false, features = ["test-util"] }

--- a/server/src/cli/certificate.rs
+++ b/server/src/cli/certificate.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use pliantdb_core::networking::fabruic::{Certificate, PrivateKey};
+use fabruic::{Certificate, PrivateKey};
 use structopt::StructOpt;
 use tokio::io::AsyncReadExt;
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use pliantdb_core::networking::fabruic;
 use pliantdb_local::core::{self, schema};
 use schema::InvalidNameError;
 

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
 impl From<Error> for core::Error {
     fn from(other: Error) -> Self {
         // without it, there's no way to get this to_string() easily.
-        #[allow(clippy::clippy::match_wildcard_for_single_variants)]
+        #[allow(clippy::match_wildcard_for_single_variants)]
         match other {
             Error::Database(storage) => Self::Database(storage.to_string()),
             Error::Core(core) => core,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -11,6 +11,7 @@ use std::{
 
 use async_trait::async_trait;
 use cfg_if::cfg_if;
+use fabruic::{self, Certificate, CertificateChain, Endpoint, KeyPair, PrivateKey};
 #[cfg(feature = "websockets")]
 use flume::Sender;
 #[cfg(feature = "websockets")]
@@ -26,9 +27,7 @@ use pliantdb_core::{
     custom_api::CustomApi,
     kv::KeyOperation,
     networking::{
-        self,
-        fabruic::{self, Certificate, CertificateChain, Endpoint, KeyPair, PrivateKey},
-        CreateDatabaseHandler, DatabaseRequest, DatabaseRequestDispatcher, DatabaseResponse,
+        self, CreateDatabaseHandler, DatabaseRequest, DatabaseRequestDispatcher, DatabaseResponse,
         DeleteDatabaseHandler, Payload, Request, RequestDispatcher, Response, ServerRequest,
         ServerRequestDispatcher, ServerResponse,
     },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,13 +6,18 @@ use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub enum Commands {
-    GenerateCodeCoverageReport,
+    GenerateCodeCoverageReport {
+        #[structopt(long = "install-dependencies")]
+        install_dependencies: bool,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
     let command = Commands::from_args();
     match command {
-        Commands::GenerateCodeCoverageReport => CodeCoverage::<CoverageConfig>::execute(),
+        Commands::GenerateCodeCoverageReport {
+            install_dependencies,
+        } => CodeCoverage::<CoverageConfig>::execute(install_dependencies),
     }
 }
 


### PR DESCRIPTION
This pull request adds the ability for `pliantdb-client` to connect over WebSockets in WebAssembly. Closes #58.

* [x] Add proper error handling
* [x] Add ability to disconnect when all clients drop
* [x] ~Investigate unit testing~ Split off to #63
* [x] Document any gotchas (not sure if there are any noteworthy).

The nice thing is that [the example doesn't need any special includes for `PliantDb` to work](https://github.com/khonsulabs/pliantdb-gooey-counter-example/blob/00e4934eec7a5c68e2ce2ede2f35224e58d77aea/client/Cargo.toml#L11-L16), so there isn't anything special to document about project setup. 